### PR TITLE
enh: add support for Spotify listening history zip instead of just individual JSON files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,9 @@
-## [Unreleased]
+## [v0.4.2] - 2025-10-14
 
 
 ### Added
 
--
--
-
-### Changed
-
--
--
-
-
-### Fixed
-
--
--
+- Add support for Spotify listening history zip instead of just the individual JSON files.
 
 ### Documentation
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,13 +7,13 @@
 
 import os
 import sys
+from memoryfm import __version__
 srcpath = os.path.abspath('../../src')
 sys.path.insert(0, srcpath)
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-from memoryfm import __version__
 project = 'memory.fm'
 copyright = '2025, Siddhant Sharma'
 author = 'Siddhant Sharma'
@@ -63,6 +63,11 @@ html_theme_options = {
         },
     ],
     "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/shsiddhant/memory.fm",
+            "icon": "fa-brands fa-github",
+        },
         {
             "name": "GitLab",
             "url": "https://gitlab.com/sharmasiddhant/memory.fm",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,6 +32,20 @@ Meant for anyone who obsesses over their music listening. Even if you aren't as 
 
          Go to QuickStart
 
+   .. grid-item-card:: API Reference
+
+      Detailed description of package API.
+
+      +++
+
+      .. button-ref:: api
+         :ref-type: ref
+         :click-parent:
+         :color: secondary
+         :expand:
+
+         Go to API Reference
+
    .. grid-item-card:: User Guide
       
       User guide for more detailed information and explanation.
@@ -47,20 +61,6 @@ Meant for anyone who obsesses over their music listening. Even if you aren't as 
          Go to user guide
 
 
-   .. grid-item-card:: API Reference
-
-      Detailed description of package API.
-
-      +++
-
-      .. button-ref:: api
-         :ref-type: ref
-         :click-parent:
-         :color: secondary
-         :expand:
-
-         Go to API Reference
-
 .. toctree::
    :hidden:
    :maxdepth: 2
@@ -71,10 +71,11 @@ Meant for anyone who obsesses over their music listening. Even if you aren't as 
    :hidden:
    :maxdepth: 2
 
-   user_guide/index
+   references/index
 
 .. toctree::
    :hidden:
    :maxdepth: 2
 
-   references/index
+   user_guide/index
+

--- a/docs/source/quickstart/cli_usage.rst
+++ b/docs/source/quickstart/cli_usage.rst
@@ -1,9 +1,9 @@
 
 .. _usage-cli:
 
-====
-CLI
-====
+============
+Command Line
+============
 
 Installing memory.fm gives you access to a command line tool 
 ``memoryfm``. 

--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -11,5 +11,5 @@ A quickstart guide for newcomers.
    :maxdepth: 2
 
    installation
-   library_usage
    cli_usage
+   library_usage

--- a/docs/source/quickstart/installation.rst
+++ b/docs/source/quickstart/installation.rst
@@ -10,7 +10,7 @@ directly from the repository with pip.
 
 .. sourcecode:: shell
    
-   $ pip install "memory.fm @ git+https://gitlab.com/sharmasiddhant/memory.fm.git"
+   $ pip install "memory.fm @ git+https://github.com/shsiddhant/memory.fm.git"
 
 `ScrobbleLog` dates are timezone aware. If you want your timezone to be automatically
 found from your system, you need to install the package with the optional dependency 
@@ -18,7 +18,7 @@ group "timezone".
 
 .. sourcecode:: shell
 
-   $ pip install "memory.fm[timezone] @ git+https://gitlab.com/sharmasiddhant/memory.fm.git"
+   $ pip install "memory.fm[timezone] @ git+https://github.com/shsiddhant/memory.fm.git"
 
 .. note::
    You will need Python version 3.10 or above.

--- a/docs/source/quickstart/library_usage.rst
+++ b/docs/source/quickstart/library_usage.rst
@@ -30,7 +30,7 @@ Optionally, you can set a timezone using IANA strings.
 
 
 .. seealso::
-   See :func:`from_spotify` to read Spotify listening history.
+   See :func:`from_spotify` and :func:`from_spotify_zip` for reading Spotify listening history.
 
 
 Head and Tail

--- a/docs/source/references/api/memoryfm.from_spotify_zip.rst
+++ b/docs/source/references/api/memoryfm.from_spotify_zip.rst
@@ -1,0 +1,6 @@
+﻿memoryfm.from\_spotify\_zip
+===========================
+
+.. currentmodule:: memoryfm
+
+.. autofunction:: from_spotify_zip

--- a/docs/source/references/io.rst
+++ b/docs/source/references/io.rst
@@ -16,6 +16,7 @@ External Sources
     
     from_lastfmstats
     from_spotify
+    from_spotify_zip
 
 Canonical Sources
 ~~~~~~~~~~~~~~~~~

--- a/src/memoryfm/__init__.py
+++ b/src/memoryfm/__init__.py
@@ -10,13 +10,17 @@ except PackageNotFoundError:
     __version__ = "0.0.0"    # Fallback value only
 
 from memoryfm.core.objects import ScrobbleLog, Scrobble
-from memoryfm.io.api import from_lastfmstats
-from memoryfm.io.spotify import from_spotify
+from memoryfm.io.api import (
+    from_lastfmstats,
+    from_spotify,
+    from_spotify_zip,
+)
 
 __all__ = [
-        "from_lastfmstats",
-        "from_spotify",
-        "ScrobbleLog",
-        "Scrobble"
+    "from_lastfmstats",
+    "from_spotify",
+    "from_spotify_zip",
+    "ScrobbleLog",
+    "Scrobble",
 ]
 

--- a/src/memoryfm/cli/import_data.py
+++ b/src/memoryfm/cli/import_data.py
@@ -32,7 +32,7 @@ def import_spotify(
     min_duration_seconds: int = 60,
 ) -> None:
     """
-    Import Spotify Listening History JSON
+    Import Spotify Listening History zip or JSON.
     """
     import_and_save(file, file_type="json", source="spotify",
                     import_name=username, overwrite=overwrite,

--- a/src/memoryfm/cli/utils/_import_utils.py
+++ b/src/memoryfm/cli/utils/_import_utils.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 from pathlib import Path
 import memoryfm
 import json
+import zipfile
 from typing import Literal
 from typer import Exit
 from memoryfm.io.lastfmstats import from_lastfmstats
-from memoryfm.io.spotify import from_spotify
+from memoryfm.io.spotify import (
+    from_spotify,
+    from_spotify_zip,
+)
 from memoryfm.io._writers import _write_string
 from memoryfm.errors import InvalidDataError
 from memoryfm.cli import (
@@ -103,6 +107,7 @@ def import_and_save(
     min_duration_seconds: int | None = 60,
 ) -> None:
     """
+    Import Last.fm scrobble data or Spotify Listening History.
     """
     ensure_files_and_dirs()
     scrobble_log = None
@@ -113,7 +118,10 @@ def import_and_save(
             scrobble_log.meta.get("username") is not None
         ):
             import_name = scrobble_log.meta.get("username")
-    elif source == "spotify":
+    elif source == "spotify" and zipfile.is_zipfile(file):
+        scrobble_log = from_spotify_zip(file, username=import_name,
+                                        min_duration_ms=min_duration_seconds*1000)
+    elif source == "spotify" and not zipfile.is_zipfile(file):
         scrobble_log = from_spotify(file, username=import_name,
                                     min_duration_ms=min_duration_seconds*1000)
     else:

--- a/src/memoryfm/core/objects.py
+++ b/src/memoryfm/core/objects.py
@@ -499,7 +499,15 @@ class ScrobbleLog:
             if self.meta.get('source') == "spotify":
                 listen = "listens"
             df = df.head(max_length)
-            bottom_text = f"Showing newest {max_length} out of {total} {listen}" 
+            if newest_first is None:
+                new_or_old = "first"
+            elif not isinstance(newest_first, bool):
+                raise TypeError("Expected boolean value for 'newest_first'")
+            elif new_or_old:
+                new_or_old = "latest"
+            else:
+                new_or_old = "first"
+            bottom_text = f"Showing {new_or_old} {max_length} out of {total} {listen}" 
         df["Timestamp"] = (
                         df["Timestamp"].dt.strftime(datetimefmt)
         )

--- a/src/memoryfm/io/_normalise.py
+++ b/src/memoryfm/io/_normalise.py
@@ -61,7 +61,8 @@ def normalise_spotify(
         'ms_played',
         'master_metadata_album_artist_name',
         'master_metadata_album_artist_name',
-        'master_metadata_track_name'
+        'master_metadata_track_name',
+        'reason_end',
     ]
     column_map = {
         'ts': 'timestamp',
@@ -73,8 +74,12 @@ def normalise_spotify(
     for column in expected_cols:
         if column not in df.columns:
             raise SchemaError(f"Missing expected column: {column}", column)
-    if min_duration_ms is not None:
+    if min_duration_ms is not None and pd.api.types.is_numeric_dtype(df['ms_played']):
         df = df[df['ms_played'] >= min_duration_ms]
+    elif not pd.api.types.is_numeric_dtype(df['ms_played']):
+        raise SchemaError(
+            "Column expected to contain only numeric values: 'ms_played'", 'ms_played'
+        )
     df = df.rename(columns=column_map)
     df = df[df['reason_end'] == "trackdone"]
     df['timestamp'] = normalise_timestamps(df['timestamp'],

--- a/src/memoryfm/io/api.py
+++ b/src/memoryfm/io/api.py
@@ -3,6 +3,13 @@ Data IO api
 """
 
 from memoryfm.io.lastfmstats import from_lastfmstats
-from memoryfm.io.spotify import from_spotify
+from memoryfm.io.spotify import (
+    from_spotify,
+    from_spotify_zip,
+)
 
-__all__ = ["from_lastfmstats", "from_spotify"]
+__all__ = [
+    "from_lastfmstats", 
+    "from_spotify", 
+    "from_spotify_zip",
+]

--- a/src/memoryfm/io/spotify.py
+++ b/src/memoryfm/io/spotify.py
@@ -4,6 +4,8 @@ Read Spotify listening history exports and return a ScrobbleLog
 
 from __future__ import annotations
 import pandas as pd
+import zipfile
+import io
 from typing import TYPE_CHECKING
 
 from memoryfm._typing import PathLike
@@ -17,14 +19,15 @@ if TYPE_CHECKING:
         AnyStr,
     )
 
-def from_spotify(
+
+def from_spotify_zip(
     file: PathLike | IO[AnyStr],
     username: str | None = None,
     tz: str | None = None,
     min_duration_ms: int | None = 60000,
-) -> ScrobbleLog:
+) -> list[str]:
     """
-    Create a ScrobbleLog from a Spotify export.
+    Create a ScrobbleLog from a Spotify listening history zip.
 
     Parameters
     ---------- 
@@ -34,7 +37,67 @@ def from_spotify(
           ``/home/username/Documents/filename``, or
         * A TextIOBase object having a ``read()`` method.
 
-        The file is expected to be a Spotify export JSON.
+        The file is expected to be a Spotify listening history zip file.
+    username : str, default None
+        A string representing username. Spotify export exports may not include the
+        username. If no username is passed, then it will be set to None.
+    tz : str, default None
+        IANA Timezone string.
+        
+        If not passed, attempt to use
+        ``tzlocal.get_localzone_name`` to calculate it. If ``tzlocal`` is not found,
+        default to 'Etc/UTC'.
+    min_duration_ms : int, default 60000
+        An integer representing the minimum duration played in milliseconds. Any
+        listen with duration less than ``min_duration_ms`` shall be discarded and
+        not included in the ScrobbleLog. Set to 60000 (1 minute) by default.
+
+    Returns
+    -------
+    ScrobbleLog
+
+    """
+    scrobble_logs_list = []
+    with zipfile.ZipFile(file) as spotify_zip:
+        json_file_list = [f.filename for f in spotify_zip.filelist if (
+            f.filename.endswith('.json') and
+            f.filename.count('Streaming_History_Audio')
+        )]
+        for name in json_file_list:
+            with spotify_zip.open(name) as json_file:
+                scrobble_logs_list.append(
+                    from_spotify(
+                        io.TextIOWrapper(json_file, encoding='UTF-8'),
+                        username,
+                        tz,
+                        min_duration_ms
+                    )
+                )
+    scrobble_log, *others = scrobble_logs_list
+    for log in others:
+        scrobble_log.append(log)
+
+    return scrobble_log
+
+ 
+def from_spotify(
+    file: PathLike | IO[AnyStr],
+    username: str | None = None,
+    tz: str | None = None,
+    min_duration_ms: int | None = 60000,
+) -> ScrobbleLog:
+    """
+    Create a ScrobbleLog from a Spotify export JSON.
+
+    Parameters
+    ---------- 
+    file : PathLike or TextIOBase object.
+        * A pathlib path, or
+        * A string corresponding to a path, such as
+          ``/home/username/Documents/filename``, or
+        * A TextIOBase object having a ``read()`` method.
+
+        The file is expected to be a Spotify listening history JSON.
     username : str, default None
         A string representing username. Spotify export exports may not include the
         username. If no username is passed, then it will be set to None.
@@ -57,5 +120,5 @@ def from_spotify(
     data = load_json(file)
     df = pd.DataFrame(data)
     scrobble_log = normalise_spotify(df=df, username=username, tz=tz,
-                                     min_duration_ms=min_duration_ms)
+                                      min_duration_ms=min_duration_ms)
     return scrobble_log

--- a/tests/io/test_io_spotify.py
+++ b/tests/io/test_io_spotify.py
@@ -1,0 +1,39 @@
+import pytest
+import pandas as pd
+# from pathlib import Path
+
+from memoryfm.errors import SchemaError
+# from memoryfm.io.spotify import (
+#     from_spotify,
+#     from_spotify_zip,
+# )
+from memoryfm.io._normalise import normalise_spotify
+
+
+class TestFromSpotify:
+
+    def test_normalise_spotify_missing_column(self):
+        data = {
+            "ts":["2024-05-05", "greenbutterfly"],
+            #"ms_played":[250000, 17120],
+            "master_metadata_track_name": ["a", "b"],
+            "master_metadata_album_album_name": ["c", "d"],
+            "master_metadata_album_artist_name": ["e", "f"]
+        }
+        msg = r"Missing expected column:.*"
+        with pytest.raises(SchemaError, match=msg):
+            normalise_spotify(df=pd.DataFrame(data), username="vartika")
+
+    def test_normalise_spotify_wrong_type(self):
+        data = {
+            "ts":["2024-05-05", "greenbutterfly"],
+            "ms_played":[250000, "themonster"],
+            "master_metadata_track_name": ["a", "b"],
+            "master_metadata_album_album_name": ["c", "d"],
+            "master_metadata_album_artist_name": ["e", "f"],
+            'reason_end': ["trackdone", "endplay"],
+        }
+        msg = r"Column expected to contain only numeric values*"
+        with pytest.raises(SchemaError, match=msg):
+            normalise_spotify(df=pd.DataFrame(data))
+


### PR DESCRIPTION
## Summary
This enhancement adds support for  Spotify listening history `zip` exports.

- **CLI:** The command `memoryfm import spotify` can now accept a `zip` export, so users need not extract it manually and import the individual JSON files.
- **Library:** The added function `memoryfm.from_spotify_zip` can create a `ScrobbleLog` from a `zip` export.
- Adding a new function instead of modifying `memoryfm.from_spotify` ensures there are no breaking changes.

## Related Issues

Closes #4 

## Type of Change

Choose one or more:

- [ ]  Bugfix
- [x]  New Feature
- [ ]  Refactor
- [x]  Documentation
- [x]  Tests
- [ ]  Build/CI

## Checklist

- [x] Code runs without errors
- [x] Tests added/updated and passed.
- [x] Documentation updated
- [x] Code style and lint checks passed
