### PR TITLE
enh: add sync button for last.fm users and a top charts page.

### DIFF
--- a/src/memoryfm/streamlit/index.py
+++ b/src/memoryfm/streamlit/index.py
@@ -12,3 +12,14 @@ overview = st.Page(
     title="Overview",
     icon=":material/list_alt:",
 )
+top_charts = st.Page(
+    page=pages / "top_charts.py",
+    title="Top Charts",
+    icon=":material/bar_chart:",
+)
+
+all_pages = [
+    home,
+    overview,
+    top_charts,
+]

--- a/src/memoryfm/streamlit/pages/home.py
+++ b/src/memoryfm/streamlit/pages/home.py
@@ -2,19 +2,23 @@ from __future__ import annotations
 import streamlit as st
 from memoryfm.cli.utils._import_utils import get_imported_names
 from memoryfm.streamlit.util import set_session_data
-from memoryfm.streamlit.manage_imports import add_user, confirm_delete
+from memoryfm.streamlit.manage_imports import add_user, confirm_delete, sync_with_api
 from memoryfm.streamlit.index import overview
 
 if "imports" not in st.session_state or st.session_state.imports is None:
     st.session_state["imports"] = get_imported_names()
+    st.session_state.imports.sort()
 if st.session_state.get("username"):
     set_session_data(st.session_state.username)
 
 
 def users_list():
+    st.session_state.imports.sort()
     for username in st.session_state.imports:
         with st.container():
-            user, delete = st.columns([1, 1])
+            user, modify = st.columns([1, 1])
+            with modify:
+                sync, delete = st.columns([1, 5])
         with user:
             if st.button(
                 f"**:material/person: {username}**",
@@ -25,6 +29,18 @@ def users_list():
                 ):
                     set_session_data(username)
                     st.switch_page(overview)
+        with sync:
+            sync_scrobbles = False
+            set_session_data(username)
+            if st.session_state["meta"]["source"] == "last.fm":
+                if st.button(
+                    "**:green[:material/sync:]**",
+                    key=f"sync {username}",
+                    type="tertiary",
+                    help="Sync scrobbles",
+                ):
+                    sync_scrobbles = True
+            st.session_state["username"] = None
         with delete:
             if st.button(
                 ":primary[:material/delete:]",
@@ -35,6 +51,8 @@ def users_list():
                 confirm_delete(username)
         if st.session_state.deleted_user:
             st.session_state.deleted_user = None
+        if sync_scrobbles:
+            sync_with_api(username)
 
 
 st.markdown(

--- a/src/memoryfm/streamlit/pages/overview.py
+++ b/src/memoryfm/streamlit/pages/overview.py
@@ -28,7 +28,7 @@ st.markdown(
 
 # Header
 if st.session_state.get("username") is not None:
-    st.title(f":primary[{st.session_state.username}]")
+    st.title(f":primary[:material/person: {st.session_state.username}]")
     ""
     set_session_data(st.session_state.username)
     # Summary Badges

--- a/src/memoryfm/streamlit/pages/top_charts.py
+++ b/src/memoryfm/streamlit/pages/top_charts.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+import streamlit as st
+from memoryfm.streamlit.util import set_session_data
+from memoryfm.streamlit.manage_imports import source_formatting
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+st.markdown(
+    """
+    <style>
+    .block-container {
+        padding-top: 1.5rem;
+        padding-bottom: 3rem;
+        padding-left: 5rem;
+        padding-right: 5rem;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+if "filter_kwargs" not in st.session_state:
+    st.session_state["filter_kwargs"] = {
+        "artists": None,
+        "albums": None,
+        "tracks": None,
+    }
+if "filter_values" not in st.session_state:
+    st.session_state["filter_values"] = []
+
+# Header
+st.title(":primary[:material/bar_chart: Top Charts]")
+"---"
+st.markdown(f"### :material/person: {st.session_state.username}")
+""
+# Date Range
+if "date_range" not in st.session_state:
+    st.session_state["date_range"] = "All Time"
+
+with st.container():
+    kind_col, dates_cols = st.columns([3, 3], border=True)
+with dates_cols:
+    st.markdown("#### :material/calendar_today: Date Range")
+    from_date_col, to_date_col = st.columns([1, 1])
+with from_date_col:
+    from_date = st.date_input(
+        label="**From**",
+        value=st.session_state.get("from"),
+        format="DD-MM-YYYY",
+    )
+with to_date_col:
+    to_date = st.date_input(
+        label="**To**",
+        value=st.session_state.get("to"),
+        format="DD-MM-YYYY",
+    )
+dates = {"from_date": from_date, "to_date": to_date}
+set_session_data(st.session_state["username"], **dates)
+
+# Format chart kind
+icons = {"artists": "artist", "albums": "album", "tracks": "music_note"}
+
+colors = {"artists": "blue", "albums": "green", "tracks": "orange"}
+filters_allowed = {
+    "artists": None,
+    "albums": ["artists"],
+    "tracks": ["artists", "albums"],
+}
+
+
+def format_chart_type(text: Literal["artists", "albums", "tracks"]):
+    return f":material/{icons[text]}: {text.capitalize()}"
+
+
+# Select Chart Type
+with kind_col:
+    st.markdown("#### :material/view_list: Chart Type")
+    kind = st.radio(
+        "Pick a chart type",
+        ["artists", "albums", "tracks"],
+        horizontal=True,
+        format_func=format_chart_type,
+    )
+
+""
+""
+
+st.subheader(
+    f":material/{icons[kind]}: Top {source_formatting(kind)}",
+)
+username = st.session_state["username"]
+set_session_data(st.session_state["username"], **dates)
+sc_log = st.session_state["sc_log"]
+with st.container(border=True):
+    if kind != "artists":
+        filters, max_length_col = st.columns(
+            [3, 1],
+            gap="large",
+            vertical_alignment="top",
+        )
+    else:
+        filters, max_length_col, *extras = st.columns(
+            [3, 1],
+            gap="large",
+            vertical_alignment="top",
+        )
+    with max_length_col:
+        st.write(f"##### {kind.capitalize()} to show")
+        max_l = st.slider(
+            "Max",
+            min_value=0,
+            max_value=50,
+            label_visibility="hidden",
+            value=10,
+            step=5,
+        )
+    if filters:
+        with filters:
+            st.markdown("##### :material/filter_list: Filter By")
+            filter_type = st.radio(
+                "Filter Type",
+                options=filters_allowed[kind],
+                format_func=format_chart_type,
+                horizontal=True,
+                label_visibility="collapsed",
+            )
+            if filter_type:
+                filter_values = st.multiselect(
+                    "Filter by",
+                    options=sorted(
+                        sc_log.df.loc[:, filter_type.rstrip("s")].dropna().unique()
+                    ),
+                    placeholder=f"Select {filter_type}",
+                    label_visibility="collapsed",
+                )
+            else:
+                filter_values = None
+            if filter_values and len(filter_values):
+                st.session_state["filter_kwargs"] = {filter_type: filter_values}
+            else:
+                st.session_state["filter_kwargs"] = {
+                    "artists": None,
+                    "albums": None,
+                    "tracks": None,
+                }
+        set_session_data(
+            st.session_state["username"], **dates, **st.session_state["filter_kwargs"]
+        )
+    sc_log = st.session_state["sc_log"]
+    if sc_log:
+        ser = sc_log.top_charts(kind)
+if sc_log:
+    st.write(ser.head(max_l).to_markdown())
+else:
+    st.info("No scrobbles found within the specified date range.")

--- a/src/memoryfm/streamlit/util.py
+++ b/src/memoryfm/streamlit/util.py
@@ -37,19 +37,26 @@ def set_session_data(
     max_length: int = 10,
     from_date: str | None = None,
     to_date: str | None = None,
+    **kwargs,
 ) -> None:
     if username is not None:
         st.session_state["username"] = username
         st.session_state["max"] = max_length
         st.session_state["sc_log"] = read_cache_from_name(
-            username, start=from_date, end=to_date
+            username, start=from_date, end=to_date, **kwargs
         )
-        st.session_state["from"] = datetime.fromisoformat(
-            st.session_state["sc_log"].meta["date_range"]["start"]
-        )
-        st.session_state["to"] = datetime.fromisoformat(
-            st.session_state["sc_log"].meta["date_range"]["end"]
-        )
+        if from_date is None:
+            st.session_state["from"] = datetime.fromisoformat(
+                st.session_state["sc_log"].meta["date_range"]["start"]
+            )
+        else:
+            st.session_state["from"] = from_date
+        if to_date is None:
+            st.session_state["to"] = datetime.fromisoformat(
+                st.session_state["sc_log"].meta["date_range"]["end"]
+            )
+        else:
+            st.session_state["to"] = to_date
         if from_date is None and to_date is None:
             st.session_state["date_range"] = "All Time"
         else:
@@ -105,6 +112,25 @@ def summary(scrobble_log) -> str:
     # {last}
     #    """
     return card
+
+
+def date_popover():
+    with st.popover(
+        st.session_state.get("date_range"),
+        icon=":material/calendar_today:",
+    ):
+        st.write("Select a date range")
+        from_date = st.date_input(
+            label="From",
+            value=st.session_state.get("from"),
+            format="DD-MM-YYYY",
+        )
+        to_date = st.date_input(
+            label="To",
+            value=st.session_state.get("to"),
+            format="DD-MM-YYYY",
+        )
+        return from_date, to_date
 
 
 def print_scrobbles(

--- a/streamlitapp.py
+++ b/streamlitapp.py
@@ -3,7 +3,7 @@ import streamlit as st
 
 from memoryfm.cli.utils._import_utils import get_imported_names
 from memoryfm.streamlit.util import print_scrobbles, set_session_data
-from memoryfm.streamlit.index import home, overview
+from memoryfm.streamlit.index import all_pages, home
 
 st.set_page_config(layout="wide")
 
@@ -57,12 +57,7 @@ def date_popover():
 
 if st.session_state.get("username"):
     scrobbles = st.Page(show_scrobbles, title="Scrobbles")
-    pages = [
-        home,
-        overview,
-        scrobbles,
-    ]
-    pg = st.navigation(pages)
+    pg = st.navigation(all_pages)
     pg.run()
 else:
     pages = [


### PR DESCRIPTION
## Summary

1. Add a top charts page with date range selection and artist/album filters.
2. Add a sync button for updating scrobbles of existing users with source 'last.fm'.

## Type of Change

Choose one or more:

- [ ]  Bugfix
- [x]  New Feature
- [ ]  Code Refactor
- [ ]  Documentation
- [ ]  Tests
- [ ]  Build/CI

## Checklist

- [x] Code runs without errors
- [x] Code style and lint checks passed
