### PR TITLE
rewrite: wrap db services into API dependencies in endpoints

### DIFF
--- a/apps/api/routers/analytics.py
+++ b/apps/api/routers/analytics.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 from typing import Literal, Annotated
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 
-from memoryfm.services.stats_service import get_top_charts_by_username
+from api.service_deps import get_stats_service
 
 router = APIRouter()
 
@@ -26,5 +26,6 @@ def top_charts(
             examples=[0, 10, 50],
         ),
     ] = 10,
+    stserv=Depends(get_stats_service),
 ):
-    return get_top_charts_by_username(username, kind, period, limit)
+    return stserv.get_top_charts_by_username(username, kind, period, limit)

--- a/apps/api/routers/user.py
+++ b/apps/api/routers/user.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 import os
 from dotenv import load_dotenv
-from fastapi import APIRouter, BackgroundTasks
+from fastapi import APIRouter, BackgroundTasks, Depends
 from fastapi.responses import JSONResponse
+
+from api.service_deps import get_stats_service
 from api.routers.websockets import task_status
 from api.response_models import RecentActivity, ScrobblesCount
 from memoryfm.io.lastfm_api import sync_lastfm_api
-import memoryfm.services.stats_service as stserv
 
 router = APIRouter()
 
@@ -25,12 +26,12 @@ async def sync_scrobbles(username: str, bg_tasks: BackgroundTasks):
 
 
 @router.get("/user/{username}/summary")
-def summary(username: str):
+def summary(username: str, stserv=Depends(get_stats_service)):
     return stserv.get_summary_by_username(username)
 
 
 @router.get("/user/{username}/recent_scrobbles", response_model=RecentActivity)
-def recent_scrobbles(username: str, weeks: int = 8):
+def recent_scrobbles(username: str, weeks: int = 8, stserv=Depends(get_stats_service)):
     data = stserv.get_daily_scrobbles_count(username, limit=weeks * 7)
     if data is not None:
         from_date, to_date, counts_seq = data

--- a/apps/api/service_deps.py
+++ b/apps/api/service_deps.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+import memoryfm.services.user_service as userv
+import memoryfm.services.stats_service as stserv
+
+
+def get_user_service():
+    return userv
+
+
+def get_stats_service():
+    return stserv

--- a/src/memoryfm/io/lastfm_api.py
+++ b/src/memoryfm/io/lastfm_api.py
@@ -136,9 +136,13 @@ def from_timestamp(
     if context:
         user_id = context.get("user_id")
         tz = context.get("tz")
-        userv.create_user(username, tz)
-    if timestamp is None or isinstance(timestamp, int):
-        from_ts = timestamp
+    userv.create_user(username, tz)
+    context = userv.get_user_context(username)
+    if context:
+        user_id = context.get("user_id")
+        tz = context.get("tz")
+    if timestamp is None or isinstance(timestamp, int | float):
+        from_ts = int(timestamp) if timestamp else timestamp
     elif isinstance(timestamp, datetime.datetime):
         from_ts = int(timestamp.timestamp())
     else:


### PR DESCRIPTION
## Pull Request Summary

This PR adds service wrappers to use as dependencies in API endpoints. It also fixes a small bug of freezing lastfm api sync for new user.

## Type of Change

Choose one or more:

- [x]  Bugfix
- [x]  Code Refactor

## Changes

### API

- Add service wrappers for user and stats 
- Use the service wrappers as dependencies in API endpoints of directly using services. This decouples API calls from DB and makes it easier to write tests for API endpoints.

### Bugfix

**Bug:** If the user doesn't exist in the database, `user_id` is None and the import doesn't happen and the batch import loop runs empty.

**Fix:** Add a create user line if user context is None. Then fetch user context and user id again to use for imports.


## Checklist

- [x] Code runs without errors
- [x] Code style and lint checks passed
