### PR TITLE
bug: fix date validation error in recent activity api endpoint

### DIFF
--- a/apps/api/routers/user.py
+++ b/apps/api/routers/user.py
@@ -36,7 +36,7 @@ def recent_scrobbles(username: str, weeks: int = 8, stserv=Depends(get_stats_ser
     if data is not None:
         from_date, to_date, counts_seq = data
         counts = [
-            ScrobblesCount(day=row["Date"], value=row["Scrobbles"])
+            ScrobblesCount(day=row["Date"].strftime("%Y-%m-%d"), value=row["Scrobbles"])
             for row in counts_seq
         ]
         return RecentActivity(from_date=from_date, to_date=to_date, counts=counts)

--- a/src/memoryfm/storage/db.py
+++ b/src/memoryfm/storage/db.py
@@ -11,7 +11,7 @@ from memoryfm.core.models import Base
 if TYPE_CHECKING:
     from sqlalchemy import Engine
 
-engine: Engine = create_engine(DB_URL)
+engine: Engine = create_engine(DB_URL, pool_size=5, max_overflow=10, pool_pre_ping=True)
 
 logging.basicConfig()
 logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)


### PR DESCRIPTION
## Pull Request Summary

This PR fixes small bug: Date validation error in recent activity api endpoint.

SQLite uses string dates, while Postgres used Datetime. The `ScrobbleCount` model use strings as `day`, so it's necessary to convert dates to string before returning or else response model validation fails.

The PR also adds pooling configuration to the database engine. 

## Type of Change

Choose one or more:

- [x]  Bugfix 
- [x] New Feature

## Changes

### API

- Convert dates in counts to string before passing to `RecentActivity` response model.

### Database

- Add engine pool configuration for future multi-user handling.

## Checklist

- [x] Code runs without errors
- [x] Code style and lint checks passed
