### PR TITLE
api: add username validation to prevent white-space value. 

### DIFF
--- a/apps/api/input_annotated_types.py
+++ b/apps/api/input_annotated_types.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+from typing import Annotated
+
+from pydantic import StringConstraints
+
+TrimmedStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]

--- a/apps/api/routers/user.py
+++ b/apps/api/routers/user.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 import os
 from dotenv import load_dotenv
-from fastapi import APIRouter, BackgroundTasks, Depends
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    Depends,
+)
 from fastapi.responses import JSONResponse
-
 from api.routers.websockets import task_status
 from api.response_models import RecentActivity, ScrobblesCount
 from memoryfm.io.lastfm_api import sync_lastfm_api
 from memoryfm.storage.db import get_db_session
 import memoryfm.services.stats_service as stserv
+from api.input_annotated_types import TrimmedStr  # noqa: TC001
 
 router = APIRouter()
 
@@ -18,7 +22,9 @@ API_KEY = os.getenv("API_KEY", "")
 
 @router.post("/user/{username}/sync")
 async def sync_scrobbles(
-    username: str, bg_tasks: BackgroundTasks, session=Depends(get_db_session)
+    username: TrimmedStr,
+    bg_tasks: BackgroundTasks,
+    session=Depends(get_db_session),
 ):
     task_status.clear()
     task_status["status"] = "running"
@@ -29,12 +35,16 @@ async def sync_scrobbles(
 
 
 @router.get("/user/{username}/summary")
-def summary(username: str, session=Depends(get_db_session)):
+def summary(username: TrimmedStr, session=Depends(get_db_session)):
     return stserv.get_summary_by_username(session, username)
 
 
 @router.get("/user/{username}/recent_scrobbles", response_model=RecentActivity)
-def recent_scrobbles(username: str, weeks: int = 8, session=Depends(get_db_session)):
+def recent_scrobbles(
+    username: TrimmedStr,
+    weeks: int = 8,
+    session=Depends(get_db_session),
+):
     data = stserv.get_daily_scrobbles_count(session, username, limit=weeks * 7)
     if data is not None:
         from_date, to_date, counts_seq = data

--- a/src/memoryfm/models/core.py
+++ b/src/memoryfm/models/core.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
-from sqlalchemy import DateTime, ForeignKey, UniqueConstraint, String
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    UniqueConstraint,
+    String,
+    func,
+)
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
     mapped_column,
     relationship,
+    validates,
 )
 
 
@@ -40,6 +48,18 @@ class User(Base):
         passive_deletes=True,
         doc="List of scrobbles of the user.",
     )
+
+    __table_args__ = (
+        CheckConstraint(
+            func.length(func.trim(username)) > 0, name="username_not_blank"
+        ),
+    )
+
+    @validates("username")
+    def validate_username(self, key, value: str):
+        if value is not None and not value.strip():
+            raise ValueError("Username cannot be empty or only whitespace")
+        return value
 
 
 class Scrobble(Base):


### PR DESCRIPTION
## Pull Request Summary

This PR enforces non-empty, white-space safe usernames in User model and API validation.

Previously, the system allowed users to be created with empty or white-space-only usernames, which could lead to inconsistent data and downstream validation issues.


## Type of Change

- [x]  New Feature

## Changes

### Models

- Add a constraint to the User model ensuring username cannot be white-space-only.
- Introduce a validation decorator to enforce this rule at the model level.

### API

- Introduce a new annotated type `TrimmedStr` based on `str` with:
  - Leading/trailing white-space stripping
  - Minimum length constraint of 1
- Update API schemas/routers to use `TrimmedStr` instead of plain `str` for username. This ensures invalid usernames are rejected early at request validation time.

## Checklist

- [x] Code runs without errors
- [x] Code style and lint checks passed
