### PR TITLE
bug: fix Last.fm “Now Playing” handling and improve response validation

### DIFF
--- a/src/memoryfm/io/lastfm_api.py
+++ b/src/memoryfm/io/lastfm_api.py
@@ -9,6 +9,7 @@ from zoneinfo import ZoneInfo
 from memoryfm.errors import InvalidDataError, UserNotFoundError
 from memoryfm.models.sync_status import SyncStatusTypes
 from memoryfm.util.format_sync_log import format_status_log
+from memoryfm.models.service_helpers import parse_lastfm_api_response
 import memoryfm.services.user_service as userv
 import memoryfm.services.scrobble_service as scserv
 
@@ -60,7 +61,9 @@ def lastfm_get_recent_tracks(
     return response
 
 
-def from_recenttracks_response(response: requests.Response) -> list[tuple]:
+def from_recenttracks_response(
+    response: requests.Response,
+) -> tuple[list[tuple[int, str, str, str]], list[str], int] | None:
     """
     Get data from last.fm API method user.getRecentTracks response.
 
@@ -91,18 +94,9 @@ def from_recenttracks_response(response: requests.Response) -> list[tuple]:
         else:
             data = jsondata["recenttracks"]["track"]
             if data:
-                scrobbles = [
-                    (
-                        int(s["date"]["uts"]),
-                        s["name"],
-                        s["artist"]["#text"],
-                        s["album"]["#text"] if (s and "album" in s) else "",
-                    )
-                    for s in data
-                ]
-                return scrobbles
+                return parse_lastfm_api_response(data)
             else:
-                return []
+                return None
 
 
 def from_timestamp(
@@ -156,12 +150,22 @@ def from_timestamp(
     sync_status.total_scrobbles = 0
     sync_status.retry = 1
     sync_status.total_retries = 5
+    skipped_count = 0
     page_block = 20
 
     while True:
-        sync_status.status = SyncStatusTypes.Progress
         _, modpage = divmod(sync_status.page, page_block)
+        # Write progress or skips every 20 pages.
         if modpage == 0:
+            # If skipped scrobbles, write warning to log
+            if skipped_count > 0:
+                sync_status.status = SyncStatusTypes.Warning
+                text = "scrobbles" if skipped_count > 1 else "scrobble"
+                skipped_text = f"Skipping {skipped_count} {text} - missing timestamps."
+                sync_status.error = skipped_text if skipped_count > 0 else None
+                logger.warning(format_status_log(username, sync_status))
+            # Write progress to log
+            sync_status.status = SyncStatusTypes.Progress
             logger.info(format_status_log(username, sync_status))
         try:
             response = lastfm_get_recent_tracks(
@@ -171,14 +175,16 @@ def from_timestamp(
                 from_ts=from_ts,
                 limit=limit,
             )
-            data_page = from_recenttracks_response(response)
-            if not data_page:
+            data = from_recenttracks_response(response)
+            if not data:
                 if sync_status.page > sync_status.totalpages:
                     sync_status.page -= 1
                 sync_status.status = SyncStatusTypes.Completed
                 logger.info(format_status_log(username, sync_status))
                 return
             elif user_id and tz:
+                data_page, _, skipped_count_page = data
+                skipped_count += skipped_count_page
                 batch = [
                     {
                         "timestamp": datetime.datetime.fromtimestamp(

--- a/src/memoryfm/models/service_helpers.py
+++ b/src/memoryfm/models/service_helpers.py
@@ -1,7 +1,42 @@
+from __future__ import annotations
+from typing import Any
 from dataclasses import dataclass
+from pydantic import AliasPath, BaseModel, Field, ValidationError
 
 
 @dataclass
 class UserContext:
     user_id: int
     tz: str
+
+
+class ScrobbleResponse(BaseModel):
+    timestamp: int = Field(validation_alias=AliasPath("date", "uts"))
+    track: str = Field(validation_alias=AliasPath("name"))
+    artist: str = Field(validation_alias=AliasPath("artist", "#text"))
+    album: str = Field(default="", validation_alias=AliasPath("album", "#text"))
+
+
+def parse_lastfm_api_response(response_data: list[dict[str, Any]]):
+    validated_data: list[tuple[int, str, str, str]] = []
+    errors: list[str] = []
+    error_count = 0
+    for scrobble in response_data:
+        if "@attr" in scrobble and scrobble["@attr"].get("nowplaying") == "true":
+            continue
+        try:
+            scrobble_valid = ScrobbleResponse.model_validate(scrobble)
+            validated_data.append(
+                (
+                    scrobble_valid.timestamp,
+                    scrobble_valid.track,
+                    scrobble_valid.artist,
+                    scrobble_valid.album,
+                )
+            )
+        except ValidationError as e:
+            error_count += e.error_count()
+            errors.extend([error.get("type") for error in e.errors()])
+            continue
+
+    return (validated_data, errors, error_count)

--- a/src/memoryfm/models/sync_status.py
+++ b/src/memoryfm/models/sync_status.py
@@ -10,6 +10,7 @@ class SyncStatusTypes(Enum):
     Completed = 3
     Retry = 4
     Error = 5
+    Warning = 6
 
 
 @dataclass
@@ -21,6 +22,7 @@ class SyncStatus:
             SyncStatusTypes.Completed,
             SyncStatusTypes.Error,
             SyncStatusTypes.Retry,
+            SyncStatusTypes.Warning,
         ]
         | None
     ) = None

--- a/src/memoryfm/util/format_sync_log.py
+++ b/src/memoryfm/util/format_sync_log.py
@@ -22,6 +22,8 @@ def format_status_log(
         text = f"[SYNC RETRY] {userinfo} | {pageinfo} | {retryinfo}"
     elif sync_status.status == SyncStatusTypes.Error:
         text = f"[SYNC ERROR] {userinfo} | {pageinfo} | {sync_status.error}"
+    elif sync_status.status == SyncStatusTypes.Warning and sync_status.error:
+        text = f"[SYNC Warning] {userinfo} | {pageinfo} | {sync_status.error}"
     else:
         raise ValueError("Invalid sync_status.status")
     return text


### PR DESCRIPTION

## Pull Request Summary

This PR fixes a bug in Last.fm sync: “Now Playing” scrobbles lack timestamp, leading to error in sync service.

It also improves validation robustness and error classification in the sync flow.

## Type of Change

- [x]  Bugfix

## Changes

### Add structured response validation

- Introduce a Pydantic model `ScrobbleResponse`, representing the expected Last.fm response structure.


### Fix “Now Playing” scrobble handling

- Add a Last.fm response parser to return valid scrobbles list for syncing to database.
- In the parser, skip “Now Playing” tracks returned by the Last.fm API.

This fixes issue where missing date caused error in sync service.

### Logging

- Log skipped track counts as warning.


## Checklist

- [x] Code runs without errors
- [x] Code style and lint checks passed
