### PR TITLE
enh: add range-based sync with backfill/recent phases and typed API parsing

### DIFF
--- a/src/memoryfm/errors.py
+++ b/src/memoryfm/errors.py
@@ -20,3 +20,10 @@ class UserNotFoundError(Exception):
     def __init__(self, username):
         self.username = username
         super().__init__(f"User not found: {self.username}")
+
+
+class LastfmAPIError(Exception):
+    def __init__(self, code: int, msg: str):
+        self.code = code
+        self.msg = msg
+        super().__init__(f"{self.code}: {self.msg}")

--- a/src/memoryfm/io/lastfm_api.py
+++ b/src/memoryfm/io/lastfm_api.py
@@ -6,16 +6,24 @@ import logging
 import datetime
 from zoneinfo import ZoneInfo
 
-from memoryfm.errors import InvalidDataError, UserNotFoundError
-from memoryfm.models.sync_status import SyncStatusTypes
+
+from memoryfm.errors import (
+    InvalidDataError,
+    UserNotFoundError,
+    LastfmAPIError,
+)
+from memoryfm.models.sync_status import SyncPhase, SyncStatusTypes
 from memoryfm.util.format_sync_log import format_status_log
 from memoryfm.models.service_helpers import parse_lastfm_api_response
 import memoryfm.services.user_service as userv
 import memoryfm.services.scrobble_service as scserv
 
+from pydantic import ValidationError
+
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
     from memoryfm.models.sync_status import SyncStatus
+    from memoryfm.models.service_helpers import LastfmResponse
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +34,7 @@ def lastfm_get_recent_tracks(
     page: int = 1,
     from_ts: int | None = None,
     to_ts: int | None = None,
-    limit: int = 180,
+    limit: int = 200,
 ) -> requests.Response:
     """
     Fetch response from last.fm API method user.getRecentTracks.
@@ -43,7 +51,7 @@ def lastfm_get_recent_tracks(
         A UNIX timestamp (in seconds). Only scrobbles since ``from_ts`` will be fetched.
     to_ts : int, Optional
         A UNIX timestamp (in seconds). Only scrobbles upto ``to_ts`` will be fetched.
-    limit : int, default 180
+    limit : int, default 200
         (Max 200) A rate limit for number of scrobbles per page.
 
     Returns
@@ -63,7 +71,7 @@ def lastfm_get_recent_tracks(
 
 def from_recenttracks_response(
     response: requests.Response,
-) -> tuple[list[tuple[int, str, str, str]], list[str], int] | None:
+) -> LastfmResponse:
     """
     Get data from last.fm API method user.getRecentTracks response.
 
@@ -74,61 +82,64 @@ def from_recenttracks_response(
 
     Returns
     -------
-    list[tuple]
-        A list of scrobble dicts, with keys - date, track, artist, album.
-        Note date column contains timestamp as integer unix timestamp in seconds.
+    LastfmResponse
+        A custom pydantic model for valid last.fm API response
 
     """
     try:
-        response.raise_for_status()
-        jsondata = response.json()
-    except requests.HTTPError as e:
-        raise requests.HTTPError(json.loads(response.text), e.args)
+        response_data = response.json()
+        return parse_lastfm_api_response(response_data)
     except json.JSONDecodeError:
         raise
-    else:
-        if "recenttracks" not in jsondata.keys():
-            raise InvalidDataError(f"Invalid Format:\n {jsondata}")
-        elif "track" not in jsondata["recenttracks"].keys():
-            raise InvalidDataError(f"Invalid Format:\n {jsondata}")
-        else:
-            data = jsondata["recenttracks"]["track"]
-            if data:
-                return parse_lastfm_api_response(data)
-            else:
-                return None
+    except InvalidDataError:
+        raise
+    except ValidationError:
+        raise
 
 
-def from_timestamp(
+def fetch_by_timestamps(
     session: Session,
     username: str,
     api_key: str,
     sync_status: SyncStatus,
-    timestamp: int | datetime.datetime | None = None,
+    from_ts: int | None = None,
+    to_ts: int | None = None,
     tz: str | None = "Etc/UTC",
-    limit: int = 180,
+    limit: int = 200,
 ):
     """
-    Fetch and insert all scrobbles after a certain timestamp.
-    Useful if you want recent scrobbles for incremental sync.
+    Fetch and insert all scrobbles between two timestamps.
+    Useful if you want incremental sync.
 
     Parameters
     ----------
+    session: Session
+        An sqlalchemy Session
     username : str
         A last.fm username.
     api_key : str
         A valid last.fm API key
-    timestamp : int, str, datetime.datetime, Optional
-        An integer UNIX timestamp (in seconds), or a string represententing
-        a valid datetime, or a datetime object.
-        Only scrobbles since ``timestamp`` will be fetched.
+    sync_status : SyncStatus
+        A SyncStatus object to store progress and status.
+        This is used to log the progress.
+    from_ts : int, Optional
+        A UNIX timestamp (in seconds). Only scrobbles since ``from_ts`` will be fetched.
+    to_ts : int, Optional
+        A UNIX timestamp (in seconds). Only scrobbles upto ``to_ts`` will be fetched.
     tz : str, Optional
         If not ``None``, ``tz`` must be a valid IANA Timezone string.
-    limit : int, default 180
+    limit : int, default 200
         (Max 200) A rate limit for number of scrobbles per page.
-
     """
-    context = None
+    sync_status.page = 1
+    sync_status.totalpages = 1
+    sync_status.fetched_scrobbles = 0
+    sync_status.total_scrobbles = 0
+    sync_status.retry = 1
+    sync_status.total_retries = 5
+    skipped_count = 0
+    page_block = 10
+
     try:
         userv.create_user(session, username, tz)
         context = userv.get_user_context(session, username)
@@ -138,24 +149,17 @@ def from_timestamp(
     except Exception:
         raise
     user_id, tz = context.user_id, context.tz
-    if timestamp is None or isinstance(timestamp, int | float):
-        from_ts = int(timestamp) if timestamp else timestamp
-    elif isinstance(timestamp, datetime.datetime):
-        from_ts = int(timestamp.timestamp())
-    else:
-        raise ValueError("Invalid timestamp.")
-    sync_status.page = 1
-    sync_status.totalpages = 1
-    sync_status.fetched_scrobbles = 0
-    sync_status.total_scrobbles = 0
-    sync_status.retry = 1
-    sync_status.total_retries = 5
-    skipped_count = 0
-    page_block = 20
 
     while True:
+        # Break loop if page exceeds total pages
+        if sync_status.page > sync_status.totalpages:
+            sync_status.page -= 1
+            sync_status.status = SyncStatusTypes.Completed
+            logger.info(format_status_log(username, sync_status))
+            break
+
+        # Write progress after every `page_block` pages.
         _, modpage = divmod(sync_status.page, page_block)
-        # Write progress or skips every 20 pages.
         if modpage == 0:
             # If skipped scrobbles, write warning to log
             if skipped_count > 0:
@@ -164,55 +168,44 @@ def from_timestamp(
                 skipped_text = f"Skipping {skipped_count} {text} - missing timestamps."
                 sync_status.error = skipped_text if skipped_count > 0 else None
                 logger.warning(format_status_log(username, sync_status))
+
             # Write progress to log
             sync_status.status = SyncStatusTypes.Progress
             logger.info(format_status_log(username, sync_status))
+
+        # Fetch scrobbles from last.fm API
         try:
             response = lastfm_get_recent_tracks(
-                username,
-                api_key,
-                page=sync_status.page,
-                from_ts=from_ts,
-                limit=limit,
+                username, api_key, sync_status.page, from_ts, to_ts, limit
             )
-            data = from_recenttracks_response(response)
-            if not data:
-                if sync_status.page > sync_status.totalpages:
-                    sync_status.page -= 1
+            valid_response = from_recenttracks_response(response)
+            batch = [
+                {
+                    "timestamp": datetime.datetime.fromtimestamp(
+                        s.timestamp, tz=ZoneInfo(tz)
+                    ),
+                    "track": s.track,
+                    "artist": s.artist,
+                    "album": s.album,
+                }
+                for s in valid_response.scrobbles
+            ]
+            if not batch:
                 sync_status.status = SyncStatusTypes.Completed
                 logger.info(format_status_log(username, sync_status))
-                return
-            elif user_id and tz:
-                data_page, _, skipped_count_page = data
-                skipped_count += skipped_count_page
-                batch = [
-                    {
-                        "timestamp": datetime.datetime.fromtimestamp(
-                            int(s[0]), tz=ZoneInfo(tz)
-                        ),
-                        "track": s[1],
-                        "artist": s[2],
-                        "album": s[3],
-                    }
-                    for s in data_page
-                ]
-                scserv.insert_scrobbles(session, user_id, batch, limit)
-                sync_status.total_scrobbles = int(
-                    response.json()["recenttracks"]["@attr"]["total"]
-                )
-                sync_status.fetched_scrobbles += len(batch)
-                sync_status.totalpages = int(
-                    response.json()["recenttracks"]["@attr"]["totalPages"]
-                )
-        except requests.HTTPError as e:
-            if (
-                e.args[0]["error"] == 8
-                and sync_status.retry <= sync_status.total_retries
-            ):
+                break
+            scserv.insert_scrobbles(session, user_id, batch)
+            sync_status.totalpages = valid_response.totalpages
+            sync_status.total_scrobbles = valid_response.total_scrobbles
+            sync_status.fetched_scrobbles += len(batch)
+        except LastfmAPIError as e:
+            if e.code == 8 and sync_status.retry <= sync_status.total_retries:
                 sync_status.retry += 1
                 sync_status.status = SyncStatusTypes.Retry
                 logger.info(format_status_log(username, sync_status))
                 continue
+            elif e.code == 6:
+                raise UserNotFoundError(username)
             else:
                 raise
         else:
@@ -226,29 +219,65 @@ def sync_lastfm_api(
     api_key: str,
     sync_status: SyncStatus,
     tz: str | None = None,
-    limit: int = 180,
+    limit: int = 200,
 ):
     """
     Fetch and sync scrobbles from a last.fm username using last.fm API.
 
     Parameters
     ----------
+    session: Session,
+        An SQLAlchemy Session
     username : str,
         A valid last.fm username.
     api_key : str,
         A valid last.fm API key.
+    sync_status : SyncStatus
+        A SyncStatus object to store progress and status.
+        This is used to log the progress.
     tz : str, Optional
         If not ``None``, ``tz`` must be a valid IANA Timezone string.
+    limit : int, default 200
+        (Max 200) A rate limit for number of scrobbles per page.
 
     """
+    first_ts, last_ts = None, None
     try:
         context = userv.get_user_context(session, username)
-        timestamp = scserv.get_max_timestamp(session, context.user_id)
+        timestamps = scserv.get_end_timestamps(session, context.user_id)
+        if timestamps:
+            first_dt, last_dt = timestamps
+            first_ts = int(first_dt.timestamp()) if first_dt else None
+            last_ts = int(last_dt.timestamp()) if last_dt else None
     except UserNotFoundError:
-        timestamp = None
+        first_ts, last_ts = None, None
     except Exception as e:
         logger.error(e)
         raise
     sync_status.status = SyncStatusTypes.Started
     logger.info(format_status_log(username, sync_status))
-    from_timestamp(session, username, api_key, sync_status, timestamp, tz, limit)
+
+    # Backfill if old missing scrobbles
+    sync_status.phase = SyncPhase.Backfill
+    fetch_by_timestamps(
+        session,
+        username,
+        api_key,
+        sync_status,
+        from_ts=None,
+        to_ts=first_ts,
+        tz=tz,
+        limit=limit,
+    )
+    # Insert recent scrobbles
+    sync_status.phase = SyncPhase.Recent
+    fetch_by_timestamps(
+        session,
+        username,
+        api_key,
+        sync_status,
+        from_ts=last_ts,
+        to_ts=None,
+        tz=tz,
+        limit=limit,
+    )

--- a/src/memoryfm/models/service_helpers.py
+++ b/src/memoryfm/models/service_helpers.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
-from typing import Any
+from typing import Annotated, Any
 from dataclasses import dataclass
-from pydantic import AliasPath, BaseModel, Field, ValidationError
+from pydantic import (
+    AliasPath,
+    BaseModel,
+    BeforeValidator,
+    Field,
+    ValidationError,
+)
+from memoryfm.errors import LastfmAPIError
 
 
 @dataclass
@@ -17,26 +24,50 @@ class ScrobbleResponse(BaseModel):
     album: str = Field(default="", validation_alias=AliasPath("album", "#text"))
 
 
-def parse_lastfm_api_response(response_data: list[dict[str, Any]]):
-    validated_data: list[tuple[int, str, str, str]] = []
-    errors: list[str] = []
-    error_count = 0
-    for scrobble in response_data:
+def skip_now_playing(scrobbles: list[Any]) -> list[ScrobbleResponse]:
+    valid_scrobbles = []
+    for scrobble in scrobbles:
         if "@attr" in scrobble and scrobble["@attr"].get("nowplaying") == "true":
             continue
         try:
             scrobble_valid = ScrobbleResponse.model_validate(scrobble)
-            validated_data.append(
-                (
-                    scrobble_valid.timestamp,
-                    scrobble_valid.track,
-                    scrobble_valid.artist,
-                    scrobble_valid.album,
-                )
-            )
-        except ValidationError as e:
-            error_count += e.error_count()
-            errors.extend([error.get("type") for error in e.errors()])
-            continue
+            valid_scrobbles.append(scrobble_valid)
+        except ValidationError:
+            raise
+    return valid_scrobbles
 
-    return (validated_data, errors, error_count)
+
+FilteredScrobbles = Annotated[
+    list[ScrobbleResponse],
+    BeforeValidator(skip_now_playing),
+]
+
+
+class LastfmResponse(BaseModel):
+    totalpages: int = Field(
+        validation_alias=AliasPath("recenttracks", "@attr", "totalPages")
+    )
+    page: int = Field(validation_alias=AliasPath("recenttracks", "@attr", "page"))
+    username: str = Field(validation_alias=AliasPath("recenttracks", "@attr", "user"))
+    total_scrobbles: int = Field(
+        validation_alias=AliasPath("recenttracks", "@attr", "total")
+    )
+    scrobbles: FilteredScrobbles = Field(
+        validation_alias=AliasPath("recenttracks", "track")
+    )
+
+
+class LastfmErrorResponse(BaseModel):
+    code: int = Field(validation_alias=AliasPath("error"))
+    msg: str = Field(validation_alias=AliasPath("message"))
+
+
+def parse_lastfm_api_response(response_data: Any) -> LastfmResponse:
+    try:
+        return LastfmResponse.model_validate(response_data)
+    except ValidationError:
+        try:
+            error_data = LastfmErrorResponse.model_validate(response_data).model_dump()
+            raise LastfmAPIError(**error_data)
+        except ValidationError:
+            raise

--- a/src/memoryfm/models/sync_status.py
+++ b/src/memoryfm/models/sync_status.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
-from typing import Literal
 from dataclasses import asdict, dataclass, fields
 from enum import Enum
+
+
+class SyncPhase(Enum):
+    Backfill = "backfill"
+    Recent = "recent"
 
 
 class SyncStatusTypes(Enum):
@@ -15,17 +19,7 @@ class SyncStatusTypes(Enum):
 
 @dataclass
 class SyncStatus:
-    status: (
-        Literal[
-            SyncStatusTypes.Started,
-            SyncStatusTypes.Progress,
-            SyncStatusTypes.Completed,
-            SyncStatusTypes.Error,
-            SyncStatusTypes.Retry,
-            SyncStatusTypes.Warning,
-        ]
-        | None
-    ) = None
+    status: SyncStatusTypes | None = None
     page: int | None = None
     totalpages: int | None = None
     fetched_scrobbles: int | None = None
@@ -33,6 +27,7 @@ class SyncStatus:
     retry: int | None = None
     total_retries: int | None = None
     error: str | None = None
+    phase: SyncPhase | None = None
 
     def clear(self):
         for field in fields(self):

--- a/src/memoryfm/services/scrobble_service.py
+++ b/src/memoryfm/services/scrobble_service.py
@@ -30,5 +30,7 @@ def insert_scrobbles(
             raise
 
 
-def get_max_timestamp(session: Session, user_id: int) -> datetime | None:
-    return screpo.get_max_timestamp_by_user(session, user_id)
+def get_end_timestamps(
+    session: Session, user_id: int
+) -> tuple[datetime, datetime] | None:
+    return screpo.get_end_timestamps_by_user(session, user_id)

--- a/src/memoryfm/storage/scrobble_repo.py
+++ b/src/memoryfm/storage/scrobble_repo.py
@@ -28,8 +28,13 @@ def insert_scrobbles_by_user(session: Session, user_id: int, scrobbles: Sequence
     session.execute(stmt, data)
 
 
-def get_max_timestamp_by_user(session: Session, user_id: int) -> datetime | None:
-    timestamp = session.scalar(
-        select(func.max(Scrobble.timestamp)).where(Scrobble.user_id == user_id)
+def get_end_timestamps_by_user(
+    session: Session, user_id: int
+) -> tuple[datetime, datetime] | None:
+    stmt = select(func.min(Scrobble.timestamp), func.max(Scrobble.timestamp)).where(
+        Scrobble.user_id == user_id
     )
-    return timestamp
+    data = session.execute(stmt).fetchone()
+    if data:
+        return data.tuple()
+    return None

--- a/src/memoryfm/util/format_sync_log.py
+++ b/src/memoryfm/util/format_sync_log.py
@@ -12,18 +12,21 @@ def format_status_log(
         f"fetched={sync_status.fetched_scrobbles}/{sync_status.total_scrobbles}"
     )
     retryinfo = f"attempt={sync_status.retry}/{sync_status.total_retries}"
+    phaseinfo = f"[{sync_status.phase.name.upper()}]" if sync_status.phase else ""
+    commoninfo = f"{phaseinfo} | {userinfo} | {pageinfo}"
+
     if sync_status.status == SyncStatusTypes.Started:
-        text = f"[SYNC STARTED] {userinfo}"
+        text = f"[SYNC STARTED] {phaseinfo} | {userinfo}"
     elif sync_status.status == SyncStatusTypes.Progress:
-        text = f"[SYNC PROGRESS] {userinfo} | {pageinfo} | {scrobbleinfo}"
+        text = f"[SYNC PROGRESS] {commoninfo} | {scrobbleinfo}"
     elif sync_status.status == SyncStatusTypes.Completed:
-        text = f"[SYNC COMPLETED] {userinfo} | {pageinfo} | {scrobbleinfo}"
+        text = f"[SYNC COMPLETED] {commoninfo} | {scrobbleinfo}"
     elif sync_status.status == SyncStatusTypes.Retry:
-        text = f"[SYNC RETRY] {userinfo} | {pageinfo} | {retryinfo}"
+        text = f"[SYNC RETRY] {commoninfo} | {retryinfo}"
     elif sync_status.status == SyncStatusTypes.Error:
-        text = f"[SYNC ERROR] {userinfo} | {pageinfo} | {sync_status.error}"
+        text = f"[SYNC ERROR] {commoninfo} | {sync_status.error}"
     elif sync_status.status == SyncStatusTypes.Warning and sync_status.error:
-        text = f"[SYNC Warning] {userinfo} | {pageinfo} | {sync_status.error}"
+        text = f"[SYNC Warning] {commoninfo} | {sync_status.error}"
     else:
         raise ValueError("Invalid sync_status.status")
     return text


### PR DESCRIPTION
## Pull Request Summary

This PR modifies the sync to backfill old scrobbles in case sync failed midway in a previous attempt. It also adds structured Last.fm Responses and improves logging with phase-aware formatting.   


## Type of Change

- [x]  New Feature
- [x]  Code Refactor

## Changes

### Last.fm Response

- Introduce `LastfmAPIError` with code and message.
- Introduce Pydantic models for Last.fm responses:
  - `FilteredScrobbles`: for filtering now playing scrobbles
  - `LastfmResponse`: for valid response with scrobbles
  - `LastfmErrorResponse`: for response containing error code and message


### Last.fm Sync

- Replace max timestamp with min/max bounds in scrobble repo / service.
- Refactor sync to use `from_ts`/`to_ts` ranges, so you get backfill and recent scrobbles synced.


### SyncStatus

- Add a `SyncPhase` enum model with Backfill and Recent names
- Extend `SyncStatus` with phase tracking with `SyncPhase` type phase attribute.


### Logging

- Show phase in sync logs to improve clarity.

## Checklist

- [x] Code runs without errors
- [x] Code style and lint checks passed
