### PR TITLE
api: refactor sync/ensure-user flow, improve state serialization, and add per-user concurrency lock

### DIFF
--- a/apps/api/routers/user.py
+++ b/apps/api/routers/user.py
@@ -29,7 +29,7 @@ async def ensure_user(
     session=Depends(get_db_session),
 ):
     bg_tasks.add_task(run_ensure_user, session, username)
-    return {"msg": f"Ensuring user exists: {username}..."}
+    return {"status": "accepted", "message": f"Ensure user task started for {username}"}
 
 
 @router.post("/user/{username}/sync")
@@ -44,7 +44,7 @@ async def sync_scrobbles(
         username,
         api_key=API_KEY,
     )
-    return {"message": f"Syncing scrobbles for user: {username}"}
+    return {"status": "accepted", "message": f"Sync task started for {username}"}
 
 
 @router.get("/user/{username}/summary", response_model=SummaryModel)

--- a/apps/api/routers/user.py
+++ b/apps/api/routers/user.py
@@ -7,16 +7,13 @@ from fastapi import (
     Depends,
 )
 from fastapi.exceptions import ResponseValidationError
-from api.state.status_services import get_ensure_user_status, get_sync_status
-from api.state.sync import run_sync
+from api.state.sync import run_sync, run_ensure_user
 from api.response_models import (
     RecentActivity,
     SummaryModel,
 )
 from memoryfm.storage.session import get_db_session
 import memoryfm.services.stats_service as stserv
-import memoryfm.services.user_service as userv
-from memoryfm.models.sync_status import SyncStatusTypes
 from api.input_annotated_types import TrimmedStr  # noqa: TC001
 
 router = APIRouter()
@@ -31,8 +28,7 @@ async def ensure_user(
     bg_tasks: BackgroundTasks,
     session=Depends(get_db_session),
 ):
-    ensure_user_status = get_ensure_user_status(username)
-    bg_tasks.add_task(userv.ensure_user, session, username, ensure_user_status)
+    bg_tasks.add_task(run_ensure_user, session, username)
     return {"msg": f"Ensuring user exists: {username}..."}
 
 
@@ -42,9 +38,6 @@ async def sync_scrobbles(
     bg_tasks: BackgroundTasks,
     session=Depends(get_db_session),
 ):
-    sync_status = get_sync_status(username)
-    sync_status.clear()
-    sync_status.status = SyncStatusTypes.Progress
     bg_tasks.add_task(
         run_sync,
         session,

--- a/apps/api/routers/websockets.py
+++ b/apps/api/routers/websockets.py
@@ -20,9 +20,9 @@ async def sync_progress_websocket(websocket: WebSocket):
         await websocket.close(1008)
         return
 
-    sync_status = get_sync_status(username)
     try:
         while True:
+            sync_status = get_sync_status(username)
             await websocket.send_json(sync_status.to_dict())
             if sync_status.status == SyncStatusTypes.Completed:
                 break

--- a/apps/api/routers/websockets.py
+++ b/apps/api/routers/websockets.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from dataclasses import asdict
 import asyncio
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from memoryfm.models.sync_status import (
@@ -41,7 +40,7 @@ async def ensure_user_websocket(websocket: WebSocket):
     ensure_user_status = get_ensure_user_status(username)
     try:
         while True:
-            await websocket.send_json(asdict(ensure_user_status))
+            await websocket.send_json(ensure_user_status.to_dict())
             if ensure_user_status.status == UserExist.Exists:
                 break
             await asyncio.sleep(1)

--- a/apps/api/state/locks.py
+++ b/apps/api/state/locks.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+import asyncio
+
+user_locks: dict[str, asyncio.Lock] = {}
+
+
+def get_lock(username: str):
+    if username not in user_locks:
+        user_locks[username] = asyncio.Lock()
+    return user_locks[username]

--- a/apps/api/state/sync.py
+++ b/apps/api/state/sync.py
@@ -2,19 +2,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 import asyncio
 
-from api.state.status_services import get_sync_status
+from api.state.status_services import get_sync_status, get_ensure_user_status
+from api.state.locks import get_lock
 from memoryfm.io.lastfm_api import sync_lastfm_api
+from memoryfm.services.user_service import ensure_user
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
-
-user_locks: dict[str, asyncio.Lock] = {}
-
-
-def get_lock(username: str):
-    if username not in user_locks:
-        user_locks[username] = asyncio.Lock()
-    return user_locks[username]
 
 
 async def run_sync(session: Session, username: str, api_key: str):
@@ -28,4 +22,17 @@ async def run_sync(session: Session, username: str, api_key: str):
             username,
             api_key,
             sync_status,
+        )
+
+
+async def run_ensure_user(session: Session, username: str):
+    ensure_sync_status = get_ensure_user_status(username)
+    lock = get_lock(username)
+
+    async with lock:
+        await asyncio.to_thread(
+            ensure_user,
+            session,
+            username,
+            ensure_sync_status,
         )

--- a/src/memoryfm/models/service_helpers.py
+++ b/src/memoryfm/models/service_helpers.py
@@ -24,17 +24,24 @@ class ScrobbleResponse(BaseModel):
     album: str = Field(default="", validation_alias=AliasPath("album", "#text"))
 
 
-def skip_now_playing(scrobbles: list[Any]) -> list[ScrobbleResponse]:
+def skip_now_playing(scrobbles: Any) -> list[ScrobbleResponse]:
     valid_scrobbles = []
-    for scrobble in scrobbles:
-        if "@attr" in scrobble and scrobble["@attr"].get("nowplaying") == "true":
-            continue
-        try:
-            scrobble_valid = ScrobbleResponse.model_validate(scrobble)
-            valid_scrobbles.append(scrobble_valid)
-        except ValidationError:
-            raise
+    if isinstance(scrobbles, dict):
+        valid_scrobbles.extend(convert_single_scrobble_to_list(scrobbles))
+    elif isinstance(scrobbles, list):
+        for scrobble in scrobbles:
+            valid_scrobbles.extend(convert_single_scrobble_to_list(scrobble))
     return valid_scrobbles
+
+
+def convert_single_scrobble_to_list(scrobble: Any) -> list[ScrobbleResponse]:
+    if "@attr" in scrobble and scrobble["@attr"].get("nowplaying") == "true":
+        return []
+    try:
+        scrobble_valid = ScrobbleResponse.model_validate(scrobble)
+        return [scrobble_valid]
+    except ValidationError:
+        raise
 
 
 FilteredScrobbles = Annotated[

--- a/src/memoryfm/models/sync_status.py
+++ b/src/memoryfm/models/sync_status.py
@@ -47,6 +47,9 @@ class UserExist(Enum):
 class EnsureUserStatus:
     status: UserExist | None = None
 
+    def to_dict(self):
+        return serialize(asdict(self))
+
 
 def serialize(obj):
     if isinstance(obj, Enum):

--- a/src/memoryfm/models/sync_status.py
+++ b/src/memoryfm/models/sync_status.py
@@ -9,12 +9,12 @@ class SyncPhase(Enum):
 
 
 class SyncStatusTypes(Enum):
-    Started = 1
-    Progress = 2
-    Completed = 3
-    Retry = 4
-    Error = 5
-    Warning = 6
+    Started = "started"
+    Progress = "progress"
+    Completed = "completed"
+    Retry = "retry"
+    Error = "error"
+    Warning = "warning"
 
 
 @dataclass
@@ -34,15 +34,26 @@ class SyncStatus:
             setattr(self, field.name, None)
 
     def to_dict(self):
-        return asdict(self)
+        return serialize(asdict(self))
 
 
 class UserExist(Enum):
-    Exists = 1
-    Checking = 2
-    Error = 3
+    Exists = "exists"
+    Checking = "checking"
+    Error = "error"
 
 
 @dataclass
 class EnsureUserStatus:
     status: UserExist | None = None
+
+
+def serialize(obj):
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, dict):
+        return {k: serialize(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [serialize(v) for v in obj]
+
+    return obj


### PR DESCRIPTION
## Pull Request Summary

This PR refactors the user sync flow and centralizes locking for user operations.

It also fixes a couple of small bugs:
- Validation error when last.fm response recent tracks is a single dict instead of list.
- TypeError in sync progress web-socket due to non-serializable enum.

## Type of Change

Choose one or more:

- [x]  Bugfix
- [x]  Code Refactor


## Changes

###  Per-User Async Lock

- Add an `asyncio` lock per username
- Centralize lock management using `get_lock`
- Move lock to separate module.

### Enum Stabilization

- Convert `SyncStatusTypes` and `UserExist` enums from ints to string values.
- Add recursive `serialize()` helper to properly encode enums in API responses

### WebSocket Improvements

- Remove `asdict` usage in favor of `SyncStatus.to_dict()` to have more control on shape.
- Fix status fetching to occur inside loop (ensures fresh state each iteration) 

### Sync State Refactor

- Move sync status management from router layer to separate state modules.


### Bugfixes

#### 1. Last.fm single scrobble response.
- **Bug:** Sometimes last.fm recent tracks is a dictionary of single scrobble instead of a list of them.
- **Fix:** Convert it to list before extending the valid scrobbles in `FilteredScrobbles` validation.

#### 2. Sync Progress Web-socket - Non-serializable response

- **Bug:** `TypeError` in sync progress web-socket due to non-serializable Status Enum
- **Fix:** Updating `SyncStatus.to_dict()` method to use serialization.



## Checklist

- [x] Code runs without errors
- [x] Code style and lint checks passed
