### PR TITLE
analytics: replace period-based filtering with explicit timestamp range in analytics.

### DIFF
--- a/apps/api/routers/analytics.py
+++ b/apps/api/routers/analytics.py
@@ -1,16 +1,18 @@
-from __future__ import annotations
+import datetime
 from typing import Literal, Annotated, Sequence
 from fastapi import APIRouter, Depends, Query
 
 from api.response_models import TopChart
-from memoryfm.models.service_enums import ChartKindColumn  # noqa: TC001
+from memoryfm.models.service_enums import ChartKindColumn
+from memoryfm.services.user_service import get_user_context
 from memoryfm.storage.session import get_db_session
 import memoryfm.services.stats_service as stserv
+from memoryfm.util.datetime_util import normalize_timestamp
 
 router = APIRouter()
 
 
-@router.get("/user/{username}/top_last", response_model=Sequence[TopChart] | None)
+@router.get("/user/{username}/top_last", response_model=Sequence[TopChart])
 def top_charts_recent(
     username: str,
     kind: Annotated[ChartKindColumn, Query(description="Type of top chart to fetch.")],
@@ -22,15 +24,51 @@ def top_charts_recent(
         ),
     ] = 7,
     limit: Annotated[
-        int,
+        int | None,
         Query(
-            description="The number of items to return. **Set to -1 to fetch all.**",
-            ge=-1,
+            description="The number of items to return.",
+            gt=0,
             examples=[0, 10, 50],
         ),
     ] = 10,
     session=Depends(get_db_session),
 ):
     """Fetch top charts by period."""
-    data = stserv.get_top_charts_by_period(session, username, kind, period, limit)
-    return data
+    return stserv.get_top_charts_by_period(session, username, kind, period, limit) or []
+
+
+@router.get("/user/{username}/top", response_model=Sequence[TopChart])
+def top_charts(
+    username: str,
+    kind: Annotated[ChartKindColumn, Query(description="Type of top chart to fetch.")],
+    from_ts: Annotated[
+        datetime.datetime | None,
+        Query(description="Fetch top charts since this date. *Use ISO 8601 datetime.*"),
+    ] = None,
+    to_ts: Annotated[
+        datetime.datetime | None,
+        Query(description="Fetch top charts upto this date. *Use ISO 8601 datetime.*"),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        Query(
+            description="The number of items to return.",
+            gt=0,
+            examples=[0, 10, 50],
+        ),
+    ] = 10,
+    session=Depends(get_db_session),
+):
+    """Fetch top charts by period."""
+    tz = get_user_context(session, username).tz
+    return (
+        stserv.get_top_charts_by_username(
+            session,
+            username,
+            kind,
+            from_ts=normalize_timestamp(from_ts, tz),
+            to_ts=normalize_timestamp(to_ts, tz),
+            limit=limit,
+        )
+        or []
+    )

--- a/apps/api/routers/analytics.py
+++ b/apps/api/routers/analytics.py
@@ -3,16 +3,17 @@ from typing import Literal, Annotated, Sequence
 from fastapi import APIRouter, Depends, Query
 
 from api.response_models import TopChart
+from memoryfm.models.service_enums import ChartKindColumn  # noqa: TC001
 from memoryfm.storage.session import get_db_session
 import memoryfm.services.stats_service as stserv
 
 router = APIRouter()
 
 
-@router.get("/user/{username}/top", response_model=Sequence[TopChart] | None)
-def top_charts(
+@router.get("/user/{username}/top_last", response_model=Sequence[TopChart] | None)
+def top_charts_recent(
     username: str,
-    kind: Literal["artist", "album", "track"],
+    kind: Annotated[ChartKindColumn, Query(description="Type of top chart to fetch.")],
     period: Annotated[
         int | Literal["all_time"],
         Query(
@@ -23,12 +24,13 @@ def top_charts(
     limit: Annotated[
         int,
         Query(
-            description="The number of items to return. **Set to -1 to fetch all**",
+            description="The number of items to return. **Set to -1 to fetch all.**",
             ge=-1,
             examples=[0, 10, 50],
         ),
     ] = 10,
     session=Depends(get_db_session),
 ):
-    data = stserv.get_top_charts_by_username(session, username, kind, period, limit)
+    """Fetch top charts by period."""
+    data = stserv.get_top_charts_by_period(session, username, kind, period, limit)
     return data

--- a/apps/api/routers/user.py
+++ b/apps/api/routers/user.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 import os
+from typing import Annotated
 from dotenv import load_dotenv
 from fastapi import (
     APIRouter,
     BackgroundTasks,
     Depends,
+    Query,
 )
 from api.state.sync import run_sync, run_ensure_user
 from api.response_models import (
@@ -27,6 +29,7 @@ async def ensure_user(
     bg_tasks: BackgroundTasks,
     session=Depends(get_db_session),
 ):
+    """Ensure that user with username exist. If not, create one."""
     bg_tasks.add_task(run_ensure_user, session, username)
     return {"status": "accepted", "message": f"Ensure user task started for {username}"}
 
@@ -37,6 +40,7 @@ async def sync_scrobbles(
     bg_tasks: BackgroundTasks,
     session=Depends(get_db_session),
 ):
+    """Sync scrobbles for user from last.fm API."""
     bg_tasks.add_task(
         run_sync,
         session,
@@ -48,14 +52,16 @@ async def sync_scrobbles(
 
 @router.get("/user/{username}/summary", response_model=SummaryModel | None)
 def summary(username: TrimmedStr, session=Depends(get_db_session)):
+    """Get summary stats for user."""
     return stserv.get_summary_by_username(session, username)
 
 
 @router.get("/user/{username}/recent_scrobbles", response_model=RecentActivity)
 def recent_scrobbles(
     username: TrimmedStr,
-    weeks: int = 8,
+    weeks: Annotated[int, Query(description="Number of weeks to fetch ", ge=1)] = 8,
     session=Depends(get_db_session),
 ):
+    """Get recent daily scrobble counts for user."""
     data = stserv.get_daily_scrobbles_count(session, username, limit=weeks * 7)
     return RecentActivity.from_service_data(data)

--- a/apps/web/src/api/user.ts
+++ b/apps/web/src/api/user.ts
@@ -50,11 +50,11 @@ export const fetchRecentActivity = async (username: string, weeks: number) => {
   return handleResponse(res);
 };
 
-export const fetchTopCharts = async (
+export const fetchTopChartsByPeriod = async (
   username: string, kind: string, period: number | "all_time", limit: number
 ) => {
   const res = await fetch(
-    `${BACKEND_URL}/user/${username}/top?kind=${kind}&period=${period}&limit=${limit}`
+    `${BACKEND_URL}/user/${username}/top_last?kind=${kind}&period=${period}&limit=${limit}`
   );
   return handleResponse(res);
 };

--- a/apps/web/src/components/pages/overview.tsx
+++ b/apps/web/src/components/pages/overview.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { fetchRecentActivity, fetchTopCharts, fetchUserSummary } from "@/api/user";
+import { fetchRecentActivity, fetchTopChartsByPeriod, fetchUserSummary } from "@/api/user";
 import { MdCalendarMonth } from "react-icons/md";
 import { Badge, Box, Container, Flex, Icon, VStack} from "@chakra-ui/react"
 import { useParams } from "react-router-dom";
@@ -52,13 +52,13 @@ export default function Overview () {
 
     const topArtistsQuery = useQuery({
         queryKey: ["topArtists", username, period, limit],
-        queryFn: () => fetchTopCharts(username, "artist", period, limit),
+        queryFn: () => fetchTopChartsByPeriod(username, "artist", period, limit),
         enabled: isValidUsername && hasValidSummary
     });
 
     const topTracksQuery = useQuery({
         queryKey: ["topTracks", username, period, limit],
-        queryFn: () => fetchTopCharts(username, "track", period, limit),
+        queryFn: () => fetchTopChartsByPeriod(username, "track", period, limit),
         enabled: isValidUsername && hasValidSummary
     });
 

--- a/src/memoryfm/services/attachment_service.py
+++ b/src/memoryfm/services/attachment_service.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Literal, Sequence
+from typing import TYPE_CHECKING, Sequence
 
 
 from memoryfm.models.service_enums import ChartKindColumn, Frequency
@@ -7,6 +7,7 @@ import memoryfm.storage.attachment_index as attrepo
 from memoryfm.storage.user_repo import get_user_by_username
 
 if TYPE_CHECKING:
+    import datetime
     from sqlalchemy.orm import Session
     from sqlalchemy import RowMapping
 
@@ -15,14 +16,17 @@ def get_renyi_entropy_by_username(
     session: Session,
     username: str,
     kind: ChartKindColumn,
-    period: int | Literal["all_time"] = 30,
+    from_ts: datetime.datetime | None = None,
+    to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
     alpha: float = 1,
 ) -> Sequence[RowMapping] | None:
     user = get_user_by_username(session, username)
     if user:
         user_id = user.id
-        return attrepo.get_renyi_entropy(session, user_id, kind, period, freq, alpha)
+        return attrepo.get_renyi_entropy(
+            session, user_id, kind, from_ts, to_ts, freq, alpha
+        )
     return None
 
 
@@ -30,12 +34,15 @@ def get_attachment_index_by_username(
     session: Session,
     username: str,
     kind: ChartKindColumn,
-    period: int | Literal["all_time"] = 30,
+    from_ts: datetime.datetime | None = None,
+    to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
     alpha: float = 1,
 ):
     user = get_user_by_username(session, username)
     if user:
         user_id = user.id
-        return attrepo.get_attachment_index(session, user_id, kind, period, freq, alpha)
+        return attrepo.get_attachment_index(
+            session, user_id, kind, from_ts, to_ts, freq, alpha
+        )
     return None

--- a/src/memoryfm/services/stats_service.py
+++ b/src/memoryfm/services/stats_service.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Literal
 from memoryfm.storage.user_repo import get_user_by_username
 import memoryfm.storage.stats_repo as strepo
-from memoryfm.util.datetime_util import get_datelimit_from_period
+from memoryfm.util.datetime_util import get_datelimit_from_period, normalize_timestamp
 
 if TYPE_CHECKING:
     from typing import Sequence
@@ -44,8 +44,12 @@ def get_top_charts_by_period(
     period: int | Literal["all_time"],
     limit: int | None = 10,
 ) -> Sequence[RowMapping] | None:
-    from_ts = get_datelimit_from_period(period)
-    return get_top_charts_by_username(session, username, kind, from_ts, limit=limit)
+    user = get_user_by_username(session, username)
+    if user:
+        tz = user.tz
+        from_ts = normalize_timestamp(get_datelimit_from_period(period), tz)
+        return get_top_charts_by_username(session, username, kind, from_ts, limit=limit)
+    return None
 
 
 def get_daily_scrobbles_count(

--- a/src/memoryfm/services/stats_service.py
+++ b/src/memoryfm/services/stats_service.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from memoryfm.storage.user_repo import get_user_by_username
 import memoryfm.storage.stats_repo as strepo
+from memoryfm.util.datetime_util import get_datelimit_from_period
 
 if TYPE_CHECKING:
-    from typing import Literal, Sequence
+    from typing import Sequence
     import datetime
     from sqlalchemy import RowMapping
     from sqlalchemy.orm import Session
+    from memoryfm.models.service_enums import ChartKindColumn
 
 
 def get_summary_by_username(session: Session, username: str) -> dict | None:
@@ -21,15 +23,29 @@ def get_summary_by_username(session: Session, username: str) -> dict | None:
 def get_top_charts_by_username(
     session: Session,
     username: str,
-    kind: Literal["artist", "album", "track"],
-    period: int | Literal["all_time"] = 7,
+    kind: ChartKindColumn,
+    from_ts: datetime.datetime | None = None,
+    to_ts: datetime.datetime | None = None,
     limit: int | None = 10,
-) -> list | None:
+) -> Sequence[RowMapping] | None:
     user = get_user_by_username(session, username)
     if user:
         user_id = user.id
-        return strepo.get_top_charts_by_user(session, user_id, kind, period, limit)
+        return strepo.get_top_charts_by_user(
+            session, user_id, kind, from_ts, to_ts, limit
+        )
     return None
+
+
+def get_top_charts_by_period(
+    session: Session,
+    username: str,
+    kind: ChartKindColumn,
+    period: int | Literal["all_time"],
+    limit: int | None = 10,
+) -> Sequence[RowMapping] | None:
+    from_ts = get_datelimit_from_period(period)
+    return get_top_charts_by_username(session, username, kind, from_ts, limit=limit)
 
 
 def get_daily_scrobbles_count(

--- a/src/memoryfm/storage/attachment_index.py
+++ b/src/memoryfm/storage/attachment_index.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
-from typing import Literal, TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Sequence
 from math import exp
 from sqlalchemy import select, func, Float
 from memoryfm.models.service_enums import Frequency
 from memoryfm.models.core import Scrobble
-from memoryfm.util.datetime_util import get_datelimit_from_period
 
 if TYPE_CHECKING:
+    import datetime
     from sqlalchemy.orm import Session
     from sqlalchemy import RowMapping
     from memoryfm.models.service_enums import (
@@ -17,19 +17,20 @@ if TYPE_CHECKING:
 def get_frequency_proportions_cte(
     user_id: int,
     kind: ChartKindColumn,
-    period: int | Literal["all_time"] = 30,
+    from_ts: datetime.datetime | None = None,
+    to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
 ):
-    datelimit = get_datelimit_from_period(period)
+    stmt_bin = select(
+        func.date_trunc(freq.value, Scrobble.timestamp).label(freq.value),
+        kind.column,
+    ).where(Scrobble.user_id == user_id)
+    if from_ts:
+        stmt_bin = stmt_bin.filter(Scrobble.timestamp >= from_ts)
+    if to_ts:
+        stmt_bin = stmt_bin.filter(Scrobble.timestamp < to_ts)
 
-    stmt_cte_bin = (
-        select(
-            func.date_trunc(freq.value, Scrobble.timestamp).label(freq.value),
-            kind.column,
-        )
-        .where(Scrobble.user_id == user_id, Scrobble.timestamp >= datelimit)
-        .cte("binned")
-    )
+    stmt_cte_bin = stmt_bin.cte("binned")
 
     stmt_cte_freq = (
         select(
@@ -60,11 +61,12 @@ def get_renyi_entropy(
     session: Session,
     user_id: int,
     kind: ChartKindColumn,
-    period: int | Literal["all_time"] = 30,
+    from_ts: datetime.datetime | None = None,
+    to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
     alpha: float = 1,
 ) -> Sequence[RowMapping] | None:
-    stmt_cte_props = get_frequency_proportions_cte(user_id, kind, period, freq)
+    stmt_cte_props = get_frequency_proportions_cte(user_id, kind, from_ts, to_ts, freq)
     cte_props_cols = stmt_cte_props.columns
     prop_col = cte_props_cols["prop"]
 
@@ -85,11 +87,12 @@ def get_attachment_index(
     session: Session,
     user_id: int,
     kind: ChartKindColumn,
-    period: int | Literal["all_time"] = 30,
+    from_ts: datetime.datetime | None = None,
+    to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
     alpha: float = 1,
 ):
-    entropy = get_renyi_entropy(session, user_id, kind, period, freq, alpha)
+    entropy = get_renyi_entropy(session, user_id, kind, from_ts, to_ts, freq, alpha)
     att_index = (
         [{"day": k["day"], "value": 100 * exp(-k["value"])} for k in entropy]
         if entropy

--- a/src/memoryfm/storage/stats_repo.py
+++ b/src/memoryfm/storage/stats_repo.py
@@ -6,9 +6,10 @@ from memoryfm.models.core import Scrobble
 from memoryfm.storage.user_repo import get_user_by_id
 
 if TYPE_CHECKING:
-    from typing import Literal, Sequence
+    from typing import Sequence
     from sqlalchemy.orm import Session
     from sqlalchemy import RowMapping
+    from memoryfm.models.service_enums import ChartKindColumn
 
 
 def get_summary_by_user(session: Session, user_id: int) -> dict | None:
@@ -55,31 +56,24 @@ def get_summary_by_user(session: Session, user_id: int) -> dict | None:
 def get_top_charts_by_user(
     session: Session,
     user_id: int,
-    kind: Literal["artist", "album", "track"],
-    period: int | Literal["all_time"] = 7,
+    kind: ChartKindColumn,
+    from_ts: datetime.datetime | None = None,
+    to_ts: datetime.datetime | None = None,
     limit: int | None = 10,
-) -> list:
-    if period != "all_time":
-        now = datetime.datetime.now()
-        datelimit = now - datetime.timedelta(days=period)
-    else:
-        datelimit = datetime.datetime.fromtimestamp(0)
-    if kind == "track":
-        col = Scrobble.track
-    elif kind == "artist":
-        col = Scrobble.artist
-    elif kind == "album":
-        col = Scrobble.album
-    else:
-        raise ValueError("Kind must be one of: 'tracks', 'artists', 'albums'")
-    data = session.execute(
+) -> Sequence[RowMapping]:
+    col = kind.column
+    stmt = (
         select(col.label("name"), func.count(Scrobble.id).label("scrobbles"))
-        .where(Scrobble.user_id == user_id, Scrobble.timestamp >= datelimit)
+        .where(Scrobble.user_id == user_id)
         .group_by("name")
         .order_by(desc("scrobbles"), desc(func.max(Scrobble.timestamp)))
         .limit(limit)
     )
-    top = list(data.mappings())
+    if from_ts:
+        stmt = stmt.filter(Scrobble.timestamp >= from_ts)
+    if to_ts:
+        stmt = stmt.filter(Scrobble.timestamp < to_ts)
+    top = session.execute(stmt).mappings().fetchall()
     return top
 
 

--- a/src/memoryfm/util/datetime_util.py
+++ b/src/memoryfm/util/datetime_util.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import datetime
 from typing import Literal
 import logging
+from zoneinfo import ZoneInfo
 from tzlocal import get_localzone_name
 
 from memoryfm.errors import InvalidDataError
@@ -38,3 +39,13 @@ def get_datelimit_from_period(period: int | Literal["all_time"] = 7):
         return datetime.datetime.now() - datetime.timedelta(days=period)
     else:
         return datetime.datetime.fromtimestamp(0)
+
+
+def normalize_timestamp(
+    timestamp: datetime.datetime | None, tz: str = "Etc/UTC"
+) -> datetime.datetime | None:
+    if not timestamp:
+        return None
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=ZoneInfo(tz))
+    return timestamp.astimezone(tz=ZoneInfo(tz))

--- a/tests/services/test_attachment.py
+++ b/tests/services/test_attachment.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING
 from math import exp, log
 
 import pytest
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 kind = ChartKindColumn.Album
 freq = Frequency.W
 username = "lazulinoother"
-period: Literal["all_time"] = "all_time"
+from_ts, to_ts = None, None
 
 renyi_entropy_expected = {1: -(5 * log(5 / 6) + log(1 / 6)) / 6, 2: -log(26 / 36)}
 att_index_expected = {k: 100 * exp(-v) for k, v in renyi_entropy_expected.items()}
@@ -25,7 +25,7 @@ att_index_expected = {k: 100 * exp(-v) for k, v in renyi_entropy_expected.items(
 def test_get_renyi_entropy(seeded_db: Session):
     for alpha, value in renyi_entropy_expected.items():
         entropy = attserv.get_renyi_entropy_by_username(
-            seeded_db, username, kind, period, freq, alpha
+            seeded_db, username, kind, from_ts, to_ts, freq, alpha
         )
         assert entropy is not None
         assert len(entropy) == 1
@@ -35,7 +35,7 @@ def test_get_renyi_entropy(seeded_db: Session):
 def test_get_attachment_index(seeded_db: Session):
     for alpha, value in att_index_expected.items():
         att_index = attserv.get_attachment_index_by_username(
-            seeded_db, username, kind, period, freq, alpha
+            seeded_db, username, kind, from_ts, to_ts, freq, alpha
         )
         assert att_index is not None
         assert len(att_index) == 1


### PR DESCRIPTION
## Pull Request Summary

This PR adds explicit timestamp range filtering for Top Charts, Rényi Entropy, and Attachment Index. It also renames the Top Charts API for period-based filtering as `/user/:username/top_last`. This allows flexibility of use.

## Type of Change

Choose one or more:

- [x]  New Feature
- [x]  Code Refactor
- [x]  Tests

## Changes

### Analytics Services

- Rename old top charts service as `get_top_charts_by_period` for period-based filtering.
- Add top charts service with timestamp range filtering.
- Replace period-based filtering with explicit timestamp range in Rényi Entropy and Attachment Index services.
- Implement `normalize_timestamp` to handle timezone-aware date comparisons.


### API

- Update Analytics API endpoints to use the new timestamp filtering.
- Add a `top_last` endpoint for period-based filtering.

### Web App

- Update backend URL for top charts.

## Checklist

- [x] Code runs without errors
- [x] Tests added/updated and passed.
- [x] Code style and lint checks passed
