### PR TITLE
web: implement UI controls and state management

### DIFF
--- a/apps/web/src/components/features/analytics/kindselector.tsx
+++ b/apps/web/src/components/features/analytics/kindselector.tsx
@@ -1,0 +1,31 @@
+import type { KindType } from "@/typing";
+import { Tabs } from "@chakra-ui/react";
+
+
+export default function KindSelector(
+    { value, onKindChange }: {
+        value: KindType
+  onKindChange: (value: KindType) => void
+    }
+) {
+    return (
+            <Tabs.Root
+                lazyMount
+                unmountOnExit
+                value={value}
+                onValueChange={(details) => onKindChange(details.value as KindType)}
+                variant="enclosed"
+                defaultValue={"artist"}
+                colorPalette={"brand"}
+            >
+                <Tabs.List>
+                    <Tabs.Trigger value="artist">Artist</Tabs.Trigger>
+                    <Tabs.Trigger value="album">Album</Tabs.Trigger>
+                    <Tabs.Trigger value="track">Track</Tabs.Trigger>
+                </Tabs.List>
+                <Tabs.Content value="kind">
+
+                </Tabs.Content>
+            </Tabs.Root>
+    )
+}

--- a/apps/web/src/components/features/analytics/limitselector.tsx
+++ b/apps/web/src/components/features/analytics/limitselector.tsx
@@ -1,0 +1,43 @@
+// Limit Selector: Max values to fetch from analytics API
+
+import { Slider } from "@chakra-ui/react"
+import { Tooltip } from "@/components/ui/tooltip"
+import { useState } from "react"
+
+export default function LimitSelector(
+    { value, onLimitChange }: {
+        value: number
+        onLimitChange: (value: number) => void
+    }
+) {
+    const [showTooltip, setShowTooltip] = useState(false)
+
+    return (
+        <Slider.Root
+            defaultValue={[10]}
+            value={[value]}
+            min={0}
+            max={100}
+            minW={"300px"}
+            variant={"solid"}
+            colorPalette={"brand"}
+            onValueChange={(details) => onLimitChange(details.value[0])}
+            onPointerEnter={() => setShowTooltip(true)}
+            onPointerLeave={() => setShowTooltip(false)}
+        >
+            <Slider.Control>
+                <Slider.Track colorPalette={"brand"}>
+                    <Slider.Range />
+                </Slider.Track>
+                <Tooltip
+                    open={showTooltip}
+                    content={<Slider.ValueText />}
+                    showArrow
+                    contentProps={{ css: { "--tooltip-bg": "var(--chakra-colors-accent)" } }}
+                >
+          <Slider.Thumb index={0} />
+        </Tooltip>
+            </Slider.Control>
+        </Slider.Root>
+    )
+}

--- a/apps/web/src/components/features/analytics/periodselector.tsx
+++ b/apps/web/src/components/features/analytics/periodselector.tsx
@@ -1,0 +1,115 @@
+// Period Selector: 7 Days, 30 Days, 365 Days, All Time, or Custom Date Range
+
+import type { Dates, Mode, ModeOption } from "@/typing";
+import {
+  DatePicker,
+  HStack,
+  Portal,
+  RadioGroup,
+  Stack,
+  type DateValue,
+} from "@chakra-ui/react";
+import { MdEditCalendar } from "react-icons/md";
+
+
+function DateSelector(
+  { label, value, onDateChange }: {
+    label: string,
+    value: DateValue[],
+    onDateChange: (values: DateValue[]) => void
+  }
+) {
+  return (
+    <>
+      <DatePicker.Root
+        maxWidth={"20rem"}
+        value={value}
+        onValueChange={(details) => onDateChange(details.value)}
+        variant="subtle"
+        colorPalette="brand"
+      >
+        <DatePicker.Label >{label}</DatePicker.Label>
+        <DatePicker.Control>
+          <DatePicker.Input />
+          <DatePicker.IndicatorGroup>
+            <DatePicker.Trigger>
+              <MdEditCalendar />
+            </DatePicker.Trigger>
+          </DatePicker.IndicatorGroup>
+        </DatePicker.Control>
+        <Portal>
+          <DatePicker.Positioner>
+            <DatePicker.Content colorPalette={"brand"}>
+              <DatePicker.View view="day">
+                <DatePicker.Header />
+                <DatePicker.DayTable />
+              </DatePicker.View>
+              <DatePicker.View view="month">
+                <DatePicker.Header />
+                <DatePicker.MonthTable />
+              </DatePicker.View>
+              <DatePicker.View view="year">
+                <DatePicker.Header />
+                <DatePicker.YearTable />
+              </DatePicker.View>
+            </DatePicker.Content>
+          </DatePicker.Positioner>
+        </Portal>
+      </DatePicker.Root>
+    </>
+  )
+}
+
+export default function PeriodSelector(
+  { mode, onModeChange, customDates, onDatesChange }: {
+    mode: Mode,
+    onModeChange: (value: Mode) => void,
+    customDates: Dates,
+    onDatesChange: (key: keyof Dates, newValues: DateValue[]) => void,
+  }
+) {
+
+  const modeOptions: ModeOption[] = [
+    { value: 7, label: "7 Days" },
+    { value: 30, label: "30 Days" },
+    { value: 365, label: "365 Days" },
+    { value: "all_time", label: "All Time" },
+    { value: "custom", label: "Custom Date Range" },
+
+  ];
+
+  return (
+    <>
+      <RadioGroup.Root
+        value={mode as string}
+        onValueChange={(details) => onModeChange(details.value as Mode)}
+        mb={"6"}
+        colorPalette="brand"
+      >
+        <HStack>
+          {modeOptions.map((item) => (
+            <RadioGroup.Item key={item.value} value={item.value as string}>
+              <RadioGroup.ItemHiddenInput />
+              <RadioGroup.ItemIndicator />
+              <RadioGroup.ItemText>{item.label}</RadioGroup.ItemText>
+            </RadioGroup.Item>
+          ))}
+        </HStack>
+      </RadioGroup.Root>
+      {mode == "custom" && (
+        <Stack direction={"row"} gap={"4"} p={"4"}>
+          <DateSelector
+            label="From"
+            value={[customDates.from_ts]}
+            onDateChange={(values) => onDatesChange("from_ts", values)}
+          />
+          <DateSelector
+            label="To"
+            value={[customDates.to_ts]}
+            onDateChange={(values) => onDatesChange("to_ts", values)}
+          />
+        </Stack>
+      )}
+    </>
+  )
+}

--- a/apps/web/src/hooks/use_analytics_params.tsx
+++ b/apps/web/src/hooks/use_analytics_params.tsx
@@ -1,0 +1,19 @@
+import { useState } from "react"
+import { type AnalyticsParams } from "@/typing"
+
+export default function useAnalyticsParams(initial: AnalyticsParams) {
+  const [params, setParams] = useState(initial)
+
+  const setParam =
+    <K extends keyof AnalyticsParams>(key: K) =>
+    (value: AnalyticsParams[K]) => {
+      setParams((prev) => ({ ...prev, [key]: value }))
+    }
+
+  return {
+    params,
+    setLimit: setParam("limit"),
+    setMode: setParam("mode"),
+    setKind: setParam("kind"),
+  }
+}

--- a/apps/web/src/typing.ts
+++ b/apps/web/src/typing.ts
@@ -1,0 +1,33 @@
+// Types and Interfaces
+
+import type { DateValue } from "@chakra-ui/react";
+
+export interface TopChart {
+    name: string,
+    scrobbles: number
+    [key: string]: string | number; 
+}
+
+export interface Dates {
+    from_ts: DateValue;
+    to_ts: DateValue;
+}
+
+// Period Selection Mode
+export type Mode = number | "all_time" | "custom";
+
+export interface ModeOption {
+  value: Mode;
+  label: string;
+}
+
+// Kind
+export type KindType = "track" | "artist" | "album"
+
+// Analytics Parameters (for analytics such as Top Charts, Attachment Index, Streaks etc)
+export type AnalyticsParams = {
+  limit: number
+  mode: Mode
+  kind: KindType
+}
+


### PR DESCRIPTION
## Pull Request Summary

This PR implements reusable UI controls like:

- `KindSelector`: Tabs for track, artist, album
- `PeriodSelector`: Period / Date Range
- `LimitSelector`: Slider for selecting limit of data to fetch

It also adds new types for analytical queries and an analytical params hook.


## Type of Change

- [x]  New Feature

## Changes

### UI Controls

- Add selector components for kind, limit, and time period filtering.
- Support custom date range selection with date picker.

### Analytics

- Define shared analytics types:
  - Mode: number of days, all_time, custom
  - KindType: track, artist, album
  - Dates: pair of dates - `from_ts` and `to_ts`
  - AnalyticsParams: limit, mode, kind
- Introduce `useAnalyticsParams` hook for centralized analytics params
  handling.