### PR TITLE
services: add service to fetch top attachment moments

### DIFF
--- a/src/memoryfm/services/attachment_service.py
+++ b/src/memoryfm/services/attachment_service.py
@@ -6,6 +6,7 @@ import numpy as np
 from memoryfm.models.service_enums import ChartKindColumn, Frequency
 import memoryfm.storage.attachment_index as attrepo
 from memoryfm.storage.user_repo import get_user_by_username
+from memoryfm.storage.stats_repo import get_top_charts_by_freq
 
 if TYPE_CHECKING:
     import datetime
@@ -71,4 +72,46 @@ def get_weighted_attachment_index_by_username(
             df["value"] = 100 * df["weight"] * np.exp(-df["value"])
             df["day"] = df["day"].dt.to_pydatetime()
             return df[["day", "value"]].to_dict(orient="records")
+        return None
+
+
+def get_attachment_moments(
+    session: Session,
+    username: str,
+    kind: ChartKindColumn,
+    from_ts: datetime.datetime | None = None,
+    to_ts: datetime.datetime | None = None,
+    freq: Frequency = Frequency.D,
+    alpha: float = 1,
+    threshold: float = 1,
+):
+    user = get_user_by_username(session, username)
+    if user:
+        user_id = user.id
+        weighted_att = get_weighted_attachment_index_by_username(
+            session,
+            username,
+            kind,
+            from_ts,
+            to_ts,
+            freq,
+            alpha,
+        )
+        top_charts = get_top_charts_by_freq(
+            session, user_id, kind, from_ts, to_ts, freq
+        )
+        if weighted_att and top_charts:
+            df = pd.DataFrame(weighted_att)
+            top_charts_df = pd.DataFrame(top_charts)
+            df["z-score"] = (df["value"] - df["value"].mean()) / df["value"].std()
+
+            top_moments_df = df[df["z-score"] >= threshold]
+            top_moments_df["day"] = top_moments_df["day"].dt.strftime("%Y-%m-%d")
+            top_moments_df[[kind.value, "scrobbles", "total_scrobbles"]] = (
+                top_charts_df[["name", "scrobbles", "total_scrobbles"]]
+            )
+            top_moments_df["dominance"] = (
+                top_moments_df["scrobbles"] / top_moments_df["total_scrobbles"]
+            )
+            return top_moments_df.to_dict(orient="records")
         return None

--- a/src/memoryfm/storage/attachment_index.py
+++ b/src/memoryfm/storage/attachment_index.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence
 from math import exp
-from sqlalchemy import select, func, Float
+from sqlalchemy import select, func
 from memoryfm.models.service_enums import Frequency
-from memoryfm.models.core import Scrobble
+from memoryfm.storage.cte_util import get_frequency_proportions_cte
 
 if TYPE_CHECKING:
     import datetime
@@ -12,50 +12,6 @@ if TYPE_CHECKING:
     from memoryfm.models.service_enums import (
         ChartKindColumn,
     )
-
-
-def get_frequency_proportions_cte(
-    user_id: int,
-    kind: ChartKindColumn,
-    from_ts: datetime.datetime | None = None,
-    to_ts: datetime.datetime | None = None,
-    freq: Frequency = Frequency.D,
-):
-    stmt_bin = select(
-        func.date_trunc(freq.value, Scrobble.timestamp).label(freq.value),
-        kind.column,
-    ).where(Scrobble.user_id == user_id)
-    if from_ts:
-        stmt_bin = stmt_bin.filter(Scrobble.timestamp >= from_ts)
-    if to_ts:
-        stmt_bin = stmt_bin.filter(Scrobble.timestamp < to_ts)
-
-    stmt_cte_bin = stmt_bin.cte("binned")
-
-    stmt_cte_freq = (
-        select(
-            stmt_cte_bin.columns[freq.value],
-            stmt_cte_bin.columns[kind.value],
-            func.count().cast(Float).label("scrobbles"),
-        )
-        .group_by(
-            stmt_cte_bin.columns[freq.value],
-            stmt_cte_bin.columns[kind.value],
-        )
-        .cte("freq")
-    )
-    cte_freq_cols = stmt_cte_freq.columns
-    scrobbles_col = cte_freq_cols["scrobbles"]
-    total_scrobbles_col = func.sum(scrobbles_col).over(
-        partition_by=cte_freq_cols[freq.value]
-    )
-    stmt_cte_props = select(
-        cte_freq_cols[freq.value],
-        cte_freq_cols[kind.value],
-        total_scrobbles_col.label("total_scrobbles"),
-        (scrobbles_col / total_scrobbles_col).label("prop"),
-    ).cte("props")
-    return stmt_cte_props
 
 
 def get_renyi_entropy(

--- a/src/memoryfm/storage/cte_util.py
+++ b/src/memoryfm/storage/cte_util.py
@@ -1,0 +1,61 @@
+import datetime
+
+from sqlalchemy import CTE, Float, func, select
+
+from memoryfm.models.core import Scrobble
+from memoryfm.models.service_enums import ChartKindColumn, Frequency
+
+
+def get_frequency_cte(
+    user_id: int,
+    kind: ChartKindColumn,
+    from_ts: datetime.datetime | None = None,
+    to_ts: datetime.datetime | None = None,
+    freq: Frequency = Frequency.D,
+) -> CTE:
+    stmt_bin = select(
+        func.date_trunc(freq.value, Scrobble.timestamp).label(freq.value),
+        kind.column,
+    ).where(Scrobble.user_id == user_id)
+    if from_ts:
+        stmt_bin = stmt_bin.filter(Scrobble.timestamp >= from_ts)
+    if to_ts:
+        stmt_bin = stmt_bin.filter(Scrobble.timestamp < to_ts)
+
+    stmt_cte_bin = stmt_bin.cte("binned")
+
+    stmt_cte_freq = (
+        select(
+            stmt_cte_bin.columns[freq.value],
+            stmt_cte_bin.columns[kind.value],
+            func.count().cast(Float).label("scrobbles"),
+        )
+        .group_by(
+            stmt_cte_bin.columns[freq.value],
+            stmt_cte_bin.columns[kind.value],
+        )
+        .cte("freq")
+    )
+    return stmt_cte_freq
+
+
+def get_frequency_proportions_cte(
+    user_id: int,
+    kind: ChartKindColumn,
+    from_ts: datetime.datetime | None = None,
+    to_ts: datetime.datetime | None = None,
+    freq: Frequency = Frequency.D,
+) -> CTE:
+    stmt_cte_freq = get_frequency_cte(user_id, kind, from_ts, to_ts, freq)
+    cte_freq_cols = stmt_cte_freq.columns
+    scrobbles_col = cte_freq_cols["scrobbles"]
+    total_scrobbles_col = func.sum(scrobbles_col).over(
+        partition_by=cte_freq_cols[freq.value]
+    )
+    stmt_cte_props = select(
+        cte_freq_cols[freq.value],
+        cte_freq_cols[kind.value],
+        total_scrobbles_col.label("total_scrobbles"),
+        (scrobbles_col / total_scrobbles_col).label("prop"),
+    ).cte("props")
+    return stmt_cte_props

--- a/src/memoryfm/storage/stats_repo.py
+++ b/src/memoryfm/storage/stats_repo.py
@@ -3,7 +3,9 @@ from typing import TYPE_CHECKING
 import datetime
 from sqlalchemy import desc, distinct, select, func
 from memoryfm.models.core import Scrobble
+from memoryfm.models.service_enums import Frequency
 from memoryfm.storage.user_repo import get_user_by_id
+from memoryfm.storage.cte_util import get_frequency_cte
 
 if TYPE_CHECKING:
     from typing import Sequence
@@ -101,3 +103,29 @@ def get_daily_scrobbles_count(
     )
     data = session.execute(stmt).mappings().all()
     return from_date, to_date, data
+
+
+def get_top_charts_by_freq(
+    session: Session,
+    user_id: int,
+    kind: ChartKindColumn,
+    from_ts: datetime.datetime | None = None,
+    to_ts: datetime.datetime | None = None,
+    freq: Frequency = Frequency.D,
+) -> Sequence[RowMapping]:
+    stmt_cte_freq = get_frequency_cte(user_id, kind, from_ts, to_ts, freq)
+    cols = stmt_cte_freq.columns
+    scrobbles_col = cols["scrobbles"]
+    total_scrobbles_col = func.sum(scrobbles_col).over(partition_by=cols[freq.value])
+    stmt = (
+        select(
+            cols[freq.value].label("day"),
+            cols[kind.value].label("name"),
+            cols["scrobbles"],
+            total_scrobbles_col.label("total_scrobbles"),
+        )
+        .distinct(cols[freq.value])
+        .order_by(cols[freq.value], desc(cols["scrobbles"]))
+    )
+    top = session.execute(stmt).mappings().fetchall()
+    return top

--- a/tests/services/test_attachment.py
+++ b/tests/services/test_attachment.py
@@ -85,3 +85,12 @@ def test_get_weighted_attachment_index(seeded_db: Session):
     assert wtd_att_index is not None
     assert len(wtd_att_index) == 2
     assert wtd_att_index[0].get("value") == pytest.approx(wtd_att_index_expected)
+
+
+def test_get_attachment_moments(seeded_db: Session):
+    moments = attserv.get_attachment_moments(
+        seeded_db, username, kind, from_ts, to_ts, freq=Frequency.D
+    )
+    assert moments is not None
+    assert len(moments) == 2
+    assert moments[1].get("track") == "Anything We Want"


### PR DESCRIPTION
## Pull Request Summary

The PR adds a service to fetch user's top attachment moments. It also adds a top charts by frequency service to fetch top track / artist / album in a periodic manner.

## Type of Change

- [x]  New Feature
- [x]  Code Refactor

## Changes

### Services

- Add a service to fetch top artist / album / track by frequency. For example to fetch user daily top artist, you would use `freq = Frequency.D`
- Add service to fetch top attachment moments. Example moment:
  ```json
  {
    "day":"2024-02-13",
    "value":70.2192816635,
    "z-score":5.7421005347,
    "album":"Eternal Sunshine of the Spotless Mind (Soundtrack from the Motion Picture)",
    "scrobbles":191.0,
    "total_scrobbles":230.0,
    "dominance":0.8304347826
  }
  ```
- Move CTE services to a separate module for better reusability.


### Tests

- Add a test for the attachment moments service.


## Checklist

- [x] Code runs without errors
- [x] Tests added/updated and passed
- [x] Code style and lint checks passed
