### PR TITLE
api: add attachment moments API endpoint

### DIFF
--- a/apps/api/response_models.py
+++ b/apps/api/response_models.py
@@ -64,3 +64,13 @@ class TopChart(BaseModel):
 class TimeSeriesData(BaseModel):
     day: date
     value: int | float
+
+
+class AttachmentMoment(BaseModel):
+    day: date
+    value: float
+    z_score: float
+    name: str
+    scrobbles: float
+    total_scrobbles: float
+    dominance: float

--- a/apps/api/routers/analytics.py
+++ b/apps/api/routers/analytics.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Literal, Annotated, Sequence
 from fastapi import APIRouter, Depends, Query
 
-from api.response_models import TimeSeriesData, TopChart
+from api.response_models import AttachmentMoment, TimeSeriesData, TopChart
 from memoryfm.models.service_enums import ChartKindColumn, Frequency
 from memoryfm.services.user_service import get_user_context
 from memoryfm.storage.session import get_db_session
@@ -131,6 +131,72 @@ def attachment_index(
             normalize_timestamp(to_ts, tz),
             freq,
             alpha,
+        )
+        or []
+    )
+
+
+@router.get(
+    "/user/{username}/attachment_moments", response_model=Sequence[AttachmentMoment]
+)
+def attachment_moments(
+    username: str,
+    kind: Annotated[
+        ChartKindColumn, Query(description="Kind of Attachment Moments to fetch.")
+    ],
+    from_ts: Annotated[
+        datetime.datetime | None,
+        Query(
+            description=(
+                "Fetch attachment moments since this datetime. *Use ISO 8601 datetime.*"
+            )
+        ),
+    ] = None,
+    to_ts: Annotated[
+        datetime.datetime | None,
+        Query(
+            description=(
+                "Fetch attachment moments upto this datetime. *Use ISO 8601 datetime.*"
+            )
+        ),
+    ] = None,
+    freq: Annotated[
+        Frequency,
+        Query(
+            description="The Frequency over which scrobble counts are grouped together."
+        ),
+    ] = Frequency.D,
+    alpha: Annotated[
+        float,
+        Query(
+            description=(
+                "Order of Attachment Index to use for attachment moments. "
+                "The order is same as order of the underlying Rényi Entropy."
+            ),
+            ge=0.5,
+            le=3.0,
+        ),
+    ] = 1,
+    threshold: Annotated[
+        float,
+        Query(
+            description="Threshold z_score for choosing top attachment moments.", ge=1
+        ),
+    ] = 1,
+    session=Depends(get_db_session),
+):
+    """Fetch Attachment Moments for user in the given datetime range."""
+    tz = get_user_context(session, username).tz
+    return (
+        attserv.get_attachment_moments(
+            session,
+            username,
+            kind,
+            normalize_timestamp(from_ts, tz),
+            normalize_timestamp(to_ts, tz),
+            freq,
+            alpha,
+            threshold,
         )
         or []
     )

--- a/src/memoryfm/services/attachment_service.py
+++ b/src/memoryfm/services/attachment_service.py
@@ -103,13 +103,13 @@ def get_attachment_moments(
         if weighted_att and top_charts:
             df = pd.DataFrame(weighted_att)
             top_charts_df = pd.DataFrame(top_charts)
-            df["z-score"] = (df["value"] - df["value"].mean()) / df["value"].std()
+            df["z_score"] = (df["value"] - df["value"].mean()) / df["value"].std()
 
-            top_moments_df = df[df["z-score"] >= threshold]
+            top_moments_df = df[df["z_score"] >= threshold]
             top_moments_df["day"] = top_moments_df["day"].dt.strftime("%Y-%m-%d")
-            top_moments_df[[kind.value, "scrobbles", "total_scrobbles"]] = (
-                top_charts_df[["name", "scrobbles", "total_scrobbles"]]
-            )
+            top_moments_df[["name", "scrobbles", "total_scrobbles"]] = top_charts_df[
+                ["name", "scrobbles", "total_scrobbles"]
+            ]
             top_moments_df["dominance"] = (
                 top_moments_df["scrobbles"] / top_moments_df["total_scrobbles"]
             )

--- a/tests/services/test_attachment.py
+++ b/tests/services/test_attachment.py
@@ -93,4 +93,4 @@ def test_get_attachment_moments(seeded_db: Session):
     )
     assert moments is not None
     assert len(moments) == 2
-    assert moments[1].get("track") == "Anything We Want"
+    assert moments[1].get("name") == "Anything We Want"


### PR DESCRIPTION
## Pull Request Summary

This PR implements an attachment moments FastAPI endpoint. It also introduces a Pydantic model `AttachmentMoment` to represent each moment.


## Type of Change

- [x]  New Feature
- [x]  Code Refactor

## Changes

### Back-end API

- Add a FastAPI endpoint `/user/:username/attachment_moments` for the attachment moments service.
- Introduce `AttachmentMoment` Pydantic model and use `Sequence[AttachmentMoment] as response model for the `attachment_moments` end-point.

### Services Refactor

- Rename `z-score` and `kind.value` in attachment moments to `z_score` and `name` to make response model easier to apply and for convenient use in the front-end.

## Checklist

- [x] Code runs without errors
- [x] Code style and lint checks passed
