### PR TITLE
enh: add API for attachment moment by period and fetch functions for attachment moments. 

### DIFF
--- a/apps/api/routers/analytics.py
+++ b/apps/api/routers/analytics.py
@@ -200,3 +200,59 @@ def attachment_moments(
         )
         or []
     )
+
+
+@router.get(
+    "/user/{username}/attachment_moments_last",
+    response_model=Sequence[AttachmentMoment],
+)
+def attachment_moments_last(
+    username: str,
+    kind: Annotated[
+        ChartKindColumn, Query(description="Kind of Attachment Moments to fetch.")
+    ],
+    period: Annotated[
+        int | Literal["all_time"],
+        Query(
+            description="Filter by period of ```period``` days. "
+            "**Set to all_time to fetch all time moments.**"
+        ),
+    ] = 90,
+    freq: Annotated[
+        Frequency,
+        Query(
+            description="The Frequency over which scrobble counts are grouped together."
+        ),
+    ] = Frequency.D,
+    alpha: Annotated[
+        float,
+        Query(
+            description=(
+                "Order of Attachment Index to use for attachment moments. "
+                "The order is same as order of the underlying Rényi Entropy."
+            ),
+            ge=0.5,
+            le=3.0,
+        ),
+    ] = 1,
+    threshold: Annotated[
+        float,
+        Query(
+            description="Threshold z_score for choosing top attachment moments.", ge=1
+        ),
+    ] = 1,
+    session=Depends(get_db_session),
+):
+    """Fetch Attachment Moments for user in the given period."""
+    return (
+        attserv.get_attachment_moments_by_period(
+            session,
+            username,
+            kind,
+            period,
+            freq,
+            alpha,
+            threshold,
+        )
+        or []
+    )

--- a/apps/web/src/api/analytics.ts
+++ b/apps/web/src/api/analytics.ts
@@ -1,0 +1,31 @@
+const BACKEND_URL = "http://127.0.0.1:8000";
+import { handleResponse } from "@/api/user";
+import type { KindType } from "@/typing";
+
+const alpha = 2;
+const threshold = 1.5;
+
+export const fetchAttachmentMoments = async(
+    { username, kind, from_ts, to_ts }: {
+        username: string;
+        kind: KindType;
+        from_ts: string | null, // ISO 8601
+        to_ts: string | null,// ISO 8601
+
+    }
+) => {
+    const res = await fetch(
+        `${BACKEND_URL}/user/${username}/attachment_moments?kind=${kind}&from_ts=${from_ts}&to_ts=${to_ts}&freq=day&alpha=${alpha}&threshold=${threshold}`
+    );
+    return handleResponse(res);
+};
+
+export const fetchAttachmentMomentsByPeriod = async (
+    username: string, kind: string, period: number | "all_time"
+) => {
+    const res = await fetch(
+        `${BACKEND_URL}/user/${username}/attachment_moments_last?kind=${kind}&period=${period}&freq=day&alpha=${alpha}&threshold=${threshold}`
+    );
+    return handleResponse(res);
+}
+

--- a/apps/web/src/api/topcharts.ts
+++ b/apps/web/src/api/topcharts.ts
@@ -1,14 +1,6 @@
 const BACKEND_URL = "http://127.0.0.1:8000";
-import { handleResponse } from "./user";
-
-
-interface ChartsInput {
-    username: string
-    kind: string,
-    from_ts: string | null, // ISO 8601
-    to_ts: string | null,// ISO 8601
-    limit: number | null,
-}
+import { handleResponse } from "@/api/user";
+import type { ChartsInput } from "@/typing";
 
 
 export const fetchTopCharts = async (

--- a/apps/web/src/typing.ts
+++ b/apps/web/src/typing.ts
@@ -8,6 +8,14 @@ export interface TopChart {
     [key: string]: string | number; 
 }
 
+export interface ChartsInput {
+    username: string
+    kind: string,
+    from_ts: string | null, // ISO 8601
+    to_ts: string | null,// ISO 8601
+    limit: number | null,
+}
+
 export interface Dates {
     from_ts: DateValue;
     to_ts: DateValue;
@@ -31,3 +39,12 @@ export type AnalyticsParams = {
   kind: KindType
 }
 
+export type AttachmentMoment = {
+  day: string
+  value: number
+  z_score: number
+  name: string
+  scrobbles: number
+  total_scrobbles: number
+  dominance: number
+}

--- a/src/memoryfm/services/attachment_service.py
+++ b/src/memoryfm/services/attachment_service.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Literal, Sequence
 import pandas as pd
 import numpy as np
 
@@ -7,6 +7,7 @@ from memoryfm.models.service_enums import ChartKindColumn, Frequency
 import memoryfm.storage.attachment_index as attrepo
 from memoryfm.storage.user_repo import get_user_by_username
 from memoryfm.storage.stats_repo import get_top_charts_by_freq
+from memoryfm.util.datetime_util import get_datelimit_from_period, normalize_timestamp
 
 if TYPE_CHECKING:
     import datetime
@@ -115,3 +116,29 @@ def get_attachment_moments(
             )
             return top_moments_df.to_dict(orient="records")
         return None
+
+
+def get_attachment_moments_by_period(
+    session: Session,
+    username: str,
+    kind: ChartKindColumn,
+    period: int | Literal["all_time"],
+    freq: Frequency = Frequency.D,
+    alpha: float = 1,
+    threshold: float = 1,
+):
+    user = get_user_by_username(session, username)
+    if user:
+        tz = user.tz
+        from_ts = normalize_timestamp(get_datelimit_from_period(period), tz)
+        return get_attachment_moments(
+            session,
+            username,
+            kind,
+            from_ts,
+            to_ts=None,
+            freq=freq,
+            alpha=alpha,
+            threshold=threshold,
+        )
+    return None


### PR DESCRIPTION
## Pull Request Summary

This PR implements API for fetching attachment moments by period, as opposed to timestamps. It also adds web API functions to fetch Attachment Moment.


## Type of Change

- [x]  New Feature
- [x]  Code Refactor

## Changes

### Services and Back-end

- Add service to fetch attachment moments by period (last N days / "all_time").
- Add a corresponding FastAPI end-point.

### Web API

- Add Attachment Moment type and move top chart interface to typing
  module.
- Add function to fetch Attachment Moments from back-end.