### PR TITLE
web: add attachment page with top attachment moments snake timeline. 

### DIFF
--- a/apps/web/src/components/features/attachment/attachment_moments.tsx
+++ b/apps/web/src/components/features/attachment/attachment_moments.tsx
@@ -1,0 +1,172 @@
+import type { AttachmentMoment } from "@/typing";
+import {
+    Flex,
+    Box,
+    Card,
+    Badge,
+    Text as ChakraText,
+    Collapsible
+} from "@chakra-ui/react";
+import { useState } from "react";
+
+
+function formatName(
+    name: string, maxChars: number
+) {
+    if (name?.length <= maxChars) {
+        return name;
+    }
+    else {
+        return name?.slice(0, maxChars - 3) + "..."
+    }
+}
+
+function MomentCard(
+    { item, key }: { item: AttachmentMoment, key: number }
+) {
+    const { day, z_score } = item;
+    const date = new Date(day);
+    const date_string = date.toLocaleDateString();
+    const [open, setOpen] = useState(false);
+
+    const getColor  = (z_score: number) => {
+        if (z_score > 3) {
+            return "brand.cardbg"
+        }
+        else {
+            return "bg"
+        }
+    } 
+
+    return (
+        <Flex
+            overflow={"auto"}
+            key={key}
+        >
+            <Box w={"240px"}>
+                <Collapsible.Root
+                    unmountOnExit
+                    open={open}
+                    onOpenChange={(details) => {
+                        setOpen(details.open);
+                    }}
+                >
+                    <Collapsible.Trigger asChild>
+                        <Card.Root
+                            variant="outline"
+                            _hover={{ bg: "brand.muted" }}
+                            transition="0.2s"
+                            padding={4}
+                            bg={getColor(z_score)}
+                        >
+                            <Flex justify="space-between" align="center">
+                                <Box>
+                                    <ChakraText fontWeight="bold">
+                                        {open ? item.name : formatName(item.name, 24)}
+                                    </ChakraText>
+                                    <Badge colorPalette={"brand"} mt={1} variant="surface" size={"md"}>
+                                        {date_string}
+                                    </Badge>
+                                </Box>
+                            </Flex>
+                            <Collapsible.Content>
+                                <Box mt={4} fontWeight={"bold"}>
+                                    <ChakraText fontSize="sm" color="accent">
+                                        Attachment Index: {item.value.toFixed(2)}
+                                    </ChakraText>
+
+                                    <ChakraText fontSize="sm">
+                                        Scrobbles: {item.scrobbles} / {item.total_scrobbles}
+                                    </ChakraText>
+
+                                    <ChakraText fontSize="sm">
+                                        Dominance: {(item.dominance * 100).toFixed(1)}%
+                                    </ChakraText>
+
+                                    <ChakraText fontSize="sm">
+                                        z-score: {item.z_score.toFixed(2)}
+                                    </ChakraText>
+                                </Box>
+                            </Collapsible.Content>
+                        </Card.Root>
+                    </Collapsible.Trigger>
+                </Collapsible.Root>
+            </Box>
+        </Flex >
+    );
+};
+
+function groupMoments(moments: AttachmentMoment[], size: number) {
+    const groups = [];
+
+    for (let i = 0; i < moments.length; i += size) {
+        groups.push(moments.slice(i, i + size));
+    }
+
+    return groups;
+}
+
+function SnakeGroup(
+    { group, index, totalGroups }: {
+        group: AttachmentMoment[],
+        index: number,
+        totalGroups: number,
+    }
+) {
+    const isEvenRow = index % 2 === 0;
+    return (
+        <Flex
+            key={index}
+            direction={isEvenRow ? "row" : "row-reverse"}
+            gap="10"
+            position={"relative"}
+            _after={index < totalGroups - 1 ? {
+                content: '""',
+                position: "absolute",
+                top: "95%",
+                right: isEvenRow ? "-20px" : "auto",
+                left: !isEvenRow ? "-20px" : "auto",
+                width: "10",
+                height: `${80}px`,
+                borderRight: isEvenRow ? "3px solid var(--chakra-colors-brand-solid)" : "none",
+                borderLeft: !isEvenRow ? "3px solid var(--chakra-colors-brand-solid)" : "none",
+                borderRadius: isEvenRow ? "0 20px 20px 0" : "20px 0 0 20px",
+            } : {}}
+        >
+            {group.map((item, idx) => (
+                <Box key={idx} position="relative">
+                    <MomentCard item={item} key={idx} />
+                    {((isEvenRow && idx < group.length - 1) || (!isEvenRow && idx > 0)) && (
+                        <Box
+                            position="absolute"
+                            top="50px"
+                            right="-10"
+                            w="10"
+                            h="1px"
+                            borderTop="3px solid var(--chakra-colors-brand-solid)"
+                            zIndex={1}
+                        />
+                    )}
+                </Box>
+            ))}
+        </Flex>
+    )
+}
+
+export default function AttachmentTimeline(
+    { moments }: { moments: AttachmentMoment[] }
+) {
+
+    const groups = groupMoments(moments, 4);
+    return (
+        <Flex direction="column" gap={12} p={10} position="relative">
+            {groups.map((group, index) => (
+                <SnakeGroup
+                    group={group}
+                    index={index}
+                    totalGroups={groups.length}
+                />
+            ))}
+        </Flex>
+    )
+}

--- a/apps/web/src/components/layout/nav_sidebar/nav_sidebar.config.ts
+++ b/apps/web/src/components/layout/nav_sidebar/nav_sidebar.config.ts
@@ -1,8 +1,9 @@
-import { MdBarChart, MdHome, MdListAlt } from "react-icons/md";
+import { MdBarChart,  MdFavorite,  MdHome, MdListAlt } from "react-icons/md";
 import type { SidebarNavItem } from "./nav_items";
 
 export const useNavItems = (username: string): SidebarNavItem[] => [
     { icon: MdHome, label: "Home", pathname: "/"},
     { icon: MdListAlt, label: "Overview", pathname: `/user/${username}/overview` },
-    { icon: MdBarChart, label: "Top Charts", pathname: `/user/${username}/topcharts`}
+    { icon: MdBarChart, label: "Top Charts", pathname: `/user/${username}/topcharts`},
+    { icon: MdFavorite, label: "Attachment", pathname: `/user/${username}/attachment`}
 ];

--- a/apps/web/src/components/pages/attachment.tsx
+++ b/apps/web/src/components/pages/attachment.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useState } from "react";
+
+// Data API
+import { fetchAttachmentMoments, fetchAttachmentMomentsByPeriod } from "@/api/analytics";
+
+import { Box, Flex, parseDate, Text as ChakraText, type DateValue, VStack, Alert } from "@chakra-ui/react";
+import Section from "@/components/ui/section";
+import PeriodSelector from "@/components/features/analytics/periodselector";
+import type { AttachmentMoment, Dates } from "@/typing";
+import { useParams } from "react-router-dom";
+import KindSelector from "../features/analytics/kindselector";
+import useAnalyticsParams from "@/hooks/use_analytics_params";
+import AttachmentTimeline from "@/components/features/attachment/attachment_moments";
+
+
+// Attachment Page
+
+
+export default function AttachmentPage() {
+
+    const { username } = useParams();
+
+    const [loading, setLoading] = useState(false);
+    const { params, setMode, setKind } = useAnalyticsParams({
+        limit: 10,
+        mode: 30,
+        kind: "artist",
+    });
+
+    const [customDates, setCustomDates] = useState<Dates>({
+        from_ts: parseDate(new Date()),
+        to_ts: parseDate(new Date())
+    });
+    const [data, setData] = useState<AttachmentMoment[]>();
+    if (!username?.trim()) {
+        return null;
+    }
+
+    useEffect(() => {
+        const loadData = async () => {
+            setLoading(true);
+            try {
+                let result: AttachmentMoment[];
+                if (params.mode == "custom") {
+                    result = await fetchAttachmentMoments({
+                        username: username,
+                        kind: params.kind,
+                        from_ts: customDates.from_ts.toString(),
+                        to_ts: customDates.to_ts.toString(),
+                    });
+                }
+                else {
+                    result = await fetchAttachmentMomentsByPeriod(
+                        username, params.kind, params.mode,
+                    )
+                }
+
+                setData(result);
+            } catch (error) {
+                console.error("Failed to load moments", error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        loadData();
+    }, [params, customDates]);
+
+
+    const handleDateChange = (key: keyof Dates, newValues: DateValue[]) => {
+        const selectedDate = newValues[0];
+        if (selectedDate) {
+            setCustomDates((prev) => ({
+                ...prev,
+                [key]: selectedDate
+            }));
+        }
+    }
+
+    if (!data) {
+        return <ChakraText>No Data Found</ChakraText>
+    }
+
+    return (
+        <Flex
+            direction="column"
+            gap={4}
+        >
+            <Box mt={"4"}>
+                <KindSelector value={params.kind} onKindChange={setKind} />
+            </Box>
+            <Flex
+                justify="space-around"
+                wrap="wrap"
+                gap={4}
+                padding={"4"}
+                mx={"12"}
+                mt={"4"}
+            >
+                <VStack align="center" gap={"4"} px="6" py="3">
+                    <ChakraText
+                        fontSize={"lg"}
+                        fontWeight={"bold"}
+                    >Period</ChakraText>
+                    <PeriodSelector
+                        mode={params.mode}
+                        onModeChange={setMode}
+                        customDates={customDates}
+                        onDatesChange={handleDateChange}
+                    />
+                </VStack>
+            </Flex>
+            {(!loading && data.length > 0) ? (
+                <>
+                    <Section
+                        title={`Top Attachment Moments - ${params.kind}s`}
+                        children={<AttachmentTimeline moments={data} />}
+                    />
+                </>
+            ) : (loading) ? (
+                <div>Loading...</div>
+            ) : (
+                <Flex justify={"center"}>
+                    <Alert.Root status={"info"} width={"sm"} justifySelf={"center"}>
+                        <Alert.Indicator />
+                        <Alert.Content>
+                            <Alert.Title>No scrobbles found in the selected period.</Alert.Title>
+                        </Alert.Content>
+                    </Alert.Root>
+                </Flex>
+            )}
+        </Flex>
+    )
+}
+

--- a/apps/web/src/components/ui/section.tsx
+++ b/apps/web/src/components/ui/section.tsx
@@ -11,14 +11,14 @@ interface SectionProps {
 const Section = ({ title, children }: SectionProps) => {
   return (
     <Flex direction="column" w="full" align="center">
-      <Box w="full" maxW="1200px">
+      <Box width="full" maxW="1200px" mx={"auto"}>
         <SectionSeparator title={title} colorToken="ticks" />
+      </Box>
         <Box as="section" mb="12" justifyItems={"center"}>
           <Stack className="content" h="full">
             {children}
           </Stack>
         </Box>
-      </Box>
     </Flex>
   );
 };

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -3,6 +3,7 @@ import AppLayout from "@/components/layout/layout"
 import HomePage from "@/components/pages/homepage"
 import Overview from "@/components/pages/overview";
 import TopChartsPage from '@/components/pages/topcharts';
+import AttachmentPage from '@/components/pages/attachment';
 
 
 export const router = createBrowserRouter([
@@ -22,6 +23,10 @@ export const router = createBrowserRouter([
             {
                 path: "topcharts",
                 element: <TopChartsPage />
+            },
+            {
+                path: "attachment",
+                element: <AttachmentPage />
             },
         ],
     },

--- a/apps/web/src/theme.ts
+++ b/apps/web/src/theme.ts
@@ -18,6 +18,9 @@ const config = defineConfig({
                     subtle: {
                         value: { _light: "#fbe0e0", _dark: "#65241f" }
                     },
+                    cardbg: {
+                        value: { _light: "#fbe0e0", _dark: "#4a1713"}
+                    },
                     fg: {
                         value: "{colors.brand.solid}"
                     },


### PR DESCRIPTION
## Pull Request Summary

This PR introduces an Attachment page that shows a snake timeline of top attachment moments, each moment displayed as a card.

## Type of Change

- [x]  Bugfix
- [x]  New Feature

## Changes

### Web UI Components

- Add `MomentCard` component to display a collapsible card for each moment.
- Add `AttachmentTimeline` to show a snake timeline of top moments.
- Create `AttachmentPage` component and show:
    - KindSelector tabs and PeriodSelector
    - `AttachmentTimeline`: snake timeline of top attachment moments.

### Theme

- Add `cardbg` color token to theme.

### Navigation

- Add attachment page to router and navigation sidebar.

### Fix Layout

- Wrap section separator inside a box to ensure correct alignment in Firefox.

