### PR TITLE
Web/attachment moments page

### DIFF
--- a/apps/api/routers/analytics.py
+++ b/apps/api/routers/analytics.py
@@ -123,7 +123,7 @@ def attachment_index(
     """Fetch Attachment Index for user in the given datetime range."""
     tz = get_user_context(session, username).tz
     return (
-        attserv.get_attachment_index_by_username(
+        attserv.get_weighted_attachment_index_by_username(
             session,
             username,
             kind,

--- a/apps/api/routers/analytics.py
+++ b/apps/api/routers/analytics.py
@@ -136,6 +136,52 @@ def attachment_index(
     )
 
 
+@router.get("/user/{username}/attachment_last", response_model=Sequence[TimeSeriesData])
+def attachment_index_last(
+    username: str,
+    kind: Annotated[
+        ChartKindColumn, Query(description="Kind of Attachment Index to fetch.")
+    ],
+    period: Annotated[
+        int | Literal["all_time"],
+        Query(
+            description="Filter by period of ```period``` days. "
+            "**Set to all_time to view all time top charts.**"
+        ),
+    ] = 7,
+    freq: Annotated[
+        Frequency,
+        Query(
+            description="The Frequency over which scrobble counts are grouped together."
+        ),
+    ] = Frequency.D,
+    alpha: Annotated[
+        float,
+        Query(
+            description=(
+                "Order of Attachment Index. "
+                "The order is same as order of the underlying Rényi Entropy."
+            ),
+            ge=0.5,
+            le=3.0,
+        ),
+    ] = 1,
+    session=Depends(get_db_session),
+):
+    """Fetch Attachment Index for user in the given period."""
+    return (
+        attserv.get_weighted_attachment_by_period(
+            session,
+            username,
+            kind,
+            period,
+            freq,
+            alpha,
+        )
+        or []
+    )
+
+
 @router.get(
     "/user/{username}/attachment_moments", response_model=Sequence[AttachmentMoment]
 )

--- a/apps/web/src/api/analytics.ts
+++ b/apps/web/src/api/analytics.ts
@@ -29,3 +29,26 @@ export const fetchAttachmentMomentsByPeriod = async (
     return handleResponse(res);
 }
 
+export const fetchAttachmentIndex = async(
+    { username, kind, from_ts, to_ts }: {
+        username: string;
+        kind: KindType;
+        from_ts: string | null, // ISO 8601
+        to_ts: string | null,// ISO 8601
+
+    }
+) => {
+    const res = await fetch(
+        `${BACKEND_URL}/user/${username}/attachment?kind=${kind}&from_ts=${from_ts}&to_ts=${to_ts}&freq=day&alpha=${alpha}`
+    );
+    return handleResponse(res);
+}
+
+export const fetchAttachmentIndexByPeriod = async (
+    username: string, kind: string, period: number | "all_time"
+) => {
+    const res = await fetch(
+        `${BACKEND_URL}/user/${username}/attachment_last?kind=${kind}&period=${period}&freq=day&alpha=${alpha}`
+    );
+    return handleResponse(res);
+}

--- a/apps/web/src/typing.ts
+++ b/apps/web/src/typing.ts
@@ -48,3 +48,8 @@ export type AttachmentMoment = {
   total_scrobbles: number
   dominance: number
 }
+
+export type TimeSeries = {
+  day: string,
+  value: number,
+}

--- a/src/memoryfm/services/attachment_service.py
+++ b/src/memoryfm/services/attachment_service.py
@@ -76,6 +76,24 @@ def get_weighted_attachment_index_by_username(
         return None
 
 
+def get_weighted_attachment_by_period(
+    session: Session,
+    username: str,
+    kind: ChartKindColumn,
+    period: int | Literal["all_time"],
+    freq: Frequency = Frequency.D,
+    alpha: float = 1,
+):
+    user = get_user_by_username(session, username)
+    if user:
+        tz = user.tz
+        from_ts = normalize_timestamp(get_datelimit_from_period(period), tz)
+        return get_attachment_index_by_username(
+            session, username, kind, from_ts, to_ts=None, freq=freq, alpha=alpha
+        )
+    return None
+
+
 def get_attachment_moments(
     session: Session,
     username: str,

--- a/src/memoryfm/services/attachment_service.py
+++ b/src/memoryfm/services/attachment_service.py
@@ -88,7 +88,7 @@ def get_weighted_attachment_by_period(
     if user:
         tz = user.tz
         from_ts = normalize_timestamp(get_datelimit_from_period(period), tz)
-        return get_attachment_index_by_username(
+        return get_weighted_attachment_index_by_username(
             session, username, kind, from_ts, to_ts=None, freq=freq, alpha=alpha
         )
     return None


### PR DESCRIPTION
## Pull Request Summary

This PR implements services and back-end API for fetching attachment index by period. It also adds web API functions to fetch attachment index by timestamps and period. 
Additionally, it fixes a small implementation bug, where attachment index was used in back-end API instead of weighted attachment index.


## Type of Change

- [x]  Bugfix
- [x]  New Feature

## Changes

### Services and Back-end

- Add service to fetch weighted attachment index by period, as opposed
  to timestamps.
- Add corresponding back-end API end-point `attachment_last`.

### Web API

- Add web API functions to fetch attachment index by timestamps and
  period.
- Add `TimeSeries` type to typing. This is useful to type annotate
  analytics timeseries data like recent activity and attachment index.

### Bugfix

- Use weighted attachment index in back-end API instead of attachment
  index.
