### PR TITLE
enh: add listening streaks api and front-end foundations for streaks 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Instead of focusing only on aggregate stats, it surfaces long-term and local pat
 ### Clone and install
 
 ```
-git clone -b rewrite https://github.com/shsiddhant/memory.fm.git
+git clone https://github.com/shsiddhant/memory.fm.git
 cd memory.fm
 pip install .
 ```

--- a/apps/api/response_models.py
+++ b/apps/api/response_models.py
@@ -78,6 +78,11 @@ class AttachmentMoment(BaseModel):
     dominance: float
 
 
+class YearRange(BaseModel):
+    start: int
+    end: int
+
+
 class ListeningStreak(BaseModel):
     start: datetime
     end: datetime

--- a/apps/api/response_models.py
+++ b/apps/api/response_models.py
@@ -1,8 +1,10 @@
-from __future__ import annotations
 from typing import Any, Sequence
 from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
 from fastapi.exceptions import ResponseValidationError
-from datetime import date
+from datetime import date, datetime
+from math import log2
+
+from memoryfm.models.service_enums import ChartKindColumn
 
 
 class ScrobblesCount(BaseModel):
@@ -74,3 +76,33 @@ class AttachmentMoment(BaseModel):
     scrobbles: float
     total_scrobbles: float
     dominance: float
+
+
+class ListeningStreak(BaseModel):
+    start: datetime
+    end: datetime
+    name: str
+    length: int
+    log_length: float
+    kind: ChartKindColumn
+
+    @classmethod
+    def from_service_data(
+        cls, kind: ChartKindColumn, data: tuple[datetime, datetime, str, int] | None
+    ):
+        schema = TypeAdapter(tuple[datetime, datetime, str, int])
+        if not data:
+            raise ResponseValidationError(errors=[{"msg": "No data found for user."}])
+        try:
+            start, end, name, length = schema.validate_python(data)
+        except ValidationError as e:
+            raise ResponseValidationError(errors=e.errors())
+        log_length = log2(length)
+        return cls(
+            start=start,
+            end=end,
+            name=name,
+            length=length,
+            log_length=log_length,
+            kind=kind,
+        )

--- a/apps/api/routers/analytics.py
+++ b/apps/api/routers/analytics.py
@@ -2,12 +2,18 @@ import datetime
 from typing import Literal, Annotated, Sequence
 from fastapi import APIRouter, Depends, Query
 
-from api.response_models import AttachmentMoment, TimeSeriesData, TopChart
+from api.response_models import (
+    AttachmentMoment,
+    ListeningStreak,
+    TimeSeriesData,
+    TopChart,
+)
 from memoryfm.models.service_enums import ChartKindColumn, Frequency
 from memoryfm.services.user_service import get_user_context
 from memoryfm.storage.session import get_db_session
 import memoryfm.services.stats_service as stserv
 import memoryfm.services.attachment_service as attserv
+import memoryfm.services.streaks_service as strkserv
 from memoryfm.util.datetime_util import normalize_timestamp
 
 router = APIRouter()
@@ -302,3 +308,31 @@ def attachment_moments_last(
         )
         or []
     )
+
+
+@router.get(
+    "/user/{username}/streaks_yearly",
+    response_model=Sequence[ListeningStreak],
+)
+def streaks(
+    username: str,
+    kind: Annotated[
+        ChartKindColumn, Query(description="Kind of listening streaks to fetch.")
+    ],
+    year: Annotated[
+        int, Query(description="Year for which streaks are to be fetched.", ge=1971)
+    ],
+    min_length: Annotated[int, Query(description="Minimum length of streaks.", ge=2)],
+    session=Depends(get_db_session),
+):
+    """Fetch listening streaks for the user in a given year."""
+    service_data = strkserv.get_streaks_by_year(
+        session,
+        username,
+        kind,
+        year,
+        min_length,
+    )
+    if not service_data:
+        return []
+    return [ListeningStreak.from_service_data(kind, streak) for streak in service_data]

--- a/apps/api/routers/user.py
+++ b/apps/api/routers/user.py
@@ -12,9 +12,11 @@ from api.state.sync import run_sync, run_ensure_user
 from api.response_models import (
     RecentActivity,
     SummaryModel,
+    YearRange,
 )
 from memoryfm.storage.session import get_db_session
 import memoryfm.services.stats_service as stserv
+from memoryfm.services.scrobble_service import get_year_range
 from api.input_annotated_types import TrimmedStr  # noqa: TC001
 
 router = APIRouter()
@@ -65,3 +67,9 @@ def recent_scrobbles(
     """Get recent daily scrobble counts for user."""
     data = stserv.get_daily_scrobbles_count(session, username, limit=weeks * 7)
     return RecentActivity.from_service_data(data)
+
+
+@router.get("/user/{username}/year_range", response_model=YearRange)
+def year_range(username: TrimmedStr, session=Depends(get_db_session)):
+    """Get scrobbling year range for user."""
+    return get_year_range(session, username)

--- a/apps/web/src/api/analytics.ts
+++ b/apps/web/src/api/analytics.ts
@@ -4,6 +4,7 @@ import type { KindType } from "@/typing";
 
 const alpha = 2;
 const threshold = 1.5;
+const min_length = 5;
 
 export const fetchAttachmentMoments = async(
     { username, kind, from_ts, to_ts }: {
@@ -49,6 +50,15 @@ export const fetchAttachmentIndexByPeriod = async (
 ) => {
     const res = await fetch(
         `${BACKEND_URL}/user/${username}/attachment_last?kind=${kind}&period=${period}&freq=day&alpha=${alpha}`
+    );
+    return handleResponse(res);
+}
+
+export const fetchStreaksByYear = async (
+    username: string, kind: KindType, year: number
+) => {
+    const res = await fetch(
+        `${BACKEND_URL}/user/${username}/streaks_yearly?kind=${kind}&year=${year}&min_length=${min_length}`
     );
     return handleResponse(res);
 }

--- a/apps/web/src/api/user.ts
+++ b/apps/web/src/api/user.ts
@@ -58,3 +58,10 @@ export const fetchTopChartsByPeriod = async (
   );
   return handleResponse(res);
 };
+
+export const fetchYearRange = async (username: string) => {
+  const res = await fetch(
+    `${BACKEND_URL}/user/${username}/year_range`
+  );
+  return handleResponse(res);
+};

--- a/apps/web/src/hooks/use_analytics_params.tsx
+++ b/apps/web/src/hooks/use_analytics_params.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react"
 import { type AnalyticsParams } from "@/typing"
+import { useQuery } from "@tanstack/react-query"
+import { fetchYearRange } from "@/api/user"
 
 export default function useAnalyticsParams(initial: AnalyticsParams) {
   const [params, setParams] = useState(initial)
@@ -16,4 +18,11 @@ export default function useAnalyticsParams(initial: AnalyticsParams) {
     setMode: setParam("mode"),
     setKind: setParam("kind"),
   }
+}
+
+export function useYearRange(username: string) {
+  return useQuery({
+    queryKey: ["year-range"],
+    queryFn: () => fetchYearRange(username)
+  });
 }

--- a/apps/web/src/typing.ts
+++ b/apps/web/src/typing.ts
@@ -53,3 +53,17 @@ export type TimeSeries = {
   day: string,
   value: number,
 }[]
+
+export type YearRange = {
+  start: number | null
+  end: number | null
+}
+
+export type ListeningStreak = {
+  start: string
+  end: string
+  name: string
+  length: number
+  log_length: number
+  kind: KindType
+}

--- a/src/memoryfm/services/scrobble_service.py
+++ b/src/memoryfm/services/scrobble_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from sqlalchemy.exc import SQLAlchemyError
 import memoryfm.storage.scrobble_repo as screpo
+from memoryfm.storage.user_repo import get_user_by_username
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -34,3 +35,15 @@ def get_end_timestamps(
     session: Session, user_id: int
 ) -> tuple[datetime, datetime] | None:
     return screpo.get_end_timestamps_by_user(session, user_id)
+
+
+def get_year_range(session: Session, username: str):
+    user = get_user_by_username(session, username)
+    start, end = None, None
+    if user:
+        user_id = user.id
+        timestamps = get_end_timestamps(session, user_id)
+        if timestamps:
+            start_ts, end_ts = timestamps
+            start, end = start_ts.year, end_ts.year
+    return {"start": start, "end": end}


### PR DESCRIPTION
## Pull Request Summary

This PR adds back-end API for fetching user's scrobble year range and yearly listening streaks. It also builds front-end foundations for listening streaks by hooks for year range and useful types.

## Type of Change

- [x]  New Feature

## Changes

### Back-end

- Add a `ListeningStreak` model to represent a single streak:
  - start: streak start timestamp
  - end: streak end timestamp
  - name: streak value (name of artist, album, track)
  - length (log_length): Length of streak (log2 of length)
  - kind: artist / album / track
- Add a class method to create `ListeningStreak` from streak
- Add a FastAPI end-point for fetching yearly streaks.
- Add service to fetch year range of user's scrobbles.
- Add FastAPI response model and end-point for year range

### Front-end

- Add front-end `ListeningStreak` and `YearRange` types.
- Add front-end API to fetch year range and listening streaks.
- Add tanstack query hook to use year range.

### Docs

- Remove rewrite branch from installation instructions.

## Checklist

- [x] Code runs without errors
- [x] Code style and lint checks passed
