### PR TITLE
enh: add an analytics view to db and improve sync error handling.

### DIFF
--- a/apps/alembic/migrations/versions/bf0507c235e9_create_analytics_view.py
+++ b/apps/alembic/migrations/versions/bf0507c235e9_create_analytics_view.py
@@ -1,0 +1,50 @@
+"""create_analytics_view
+
+Revision ID: bf0507c235e9
+Revises: e1fef182da4c
+Create Date: 2026-04-28 19:55:10.932525
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "bf0507c235e9"
+down_revision: Union[str, Sequence[str], None] = "e1fef182da4c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.execute("""
+        CREATE OR REPLACE VIEW analytics_view AS
+        SELECT
+            s.id AS scrobble_id,
+            s.timestamp,
+            u.id AS user_id,
+            u.username,
+            t.id AS track_id,
+            t.name AS track,
+            al.id AS album_id,
+            al.name AS album,
+            ar.id AS artist_id,
+            ar.name AS artist
+        FROM scrobbles s
+        JOIN users u ON s.user_id = u.id
+        JOIN tracks t ON s.track_id = t.id
+        JOIN albums al ON t.album_id = al.id
+        JOIN artists ar ON t.artist_id = ar.id
+    """)
+    op.create_index(
+        op.f("ix_scrobbles_user_id"), "scrobbles", ["user_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_scrobbles_user_id"), table_name="scrobbles")
+    op.execute("DROP VIEW analytics_view")

--- a/apps/api/state/sync.py
+++ b/apps/api/state/sync.py
@@ -1,14 +1,37 @@
 from __future__ import annotations
+import logging
 from typing import TYPE_CHECKING
 import asyncio
 
 from api.state.status_services import get_sync_status, get_ensure_user_status
 from api.state.locks import get_lock
 from memoryfm.io.lastfm_api import sync_lastfm_api
+from memoryfm.models.sync_status import SyncStatus, SyncStatusTypes
 from memoryfm.services.user_service import ensure_user
+from memoryfm.util.format_sync_log import format_status_log
+import memoryfm.errors as err
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
+
+logger = logging.getLogger("memoryfm.io.lastfm_api")
+
+
+def apply_exception_to_status(e: Exception, sync_status: SyncStatus):
+    sync_status.status = SyncStatusTypes.Error
+
+    if isinstance(
+        e,
+        (
+            err.LastfmAPIError,
+            err.UserLoginRequiredError,
+            err.APIKeyError,
+            err.RateLimitExceededError,
+        ),
+    ):
+        sync_status.error = e.msg
+    else:
+        sync_status.error = str(e)
 
 
 async def run_sync(session: Session, username: str, api_key: str):
@@ -16,13 +39,18 @@ async def run_sync(session: Session, username: str, api_key: str):
     lock = get_lock(username)
 
     async with lock:
-        await asyncio.to_thread(
-            sync_lastfm_api,
-            session,
-            username,
-            api_key,
-            sync_status,
-        )
+        sync_status.error = None
+        try:
+            await asyncio.to_thread(
+                sync_lastfm_api,
+                session,
+                username,
+                api_key,
+                sync_status,
+            )
+        except Exception as e:
+            apply_exception_to_status(e, sync_status)
+            logger.error(format_status_log(username, sync_status))
 
 
 async def run_ensure_user(session: Session, username: str):

--- a/src/memoryfm/errors.py
+++ b/src/memoryfm/errors.py
@@ -17,13 +17,38 @@ class SchemaError(InvalidDataError):
 
 
 class UserNotFoundError(Exception):
+    """If username doesn't exist on Last.fm."""
+
     def __init__(self, username):
         self.username = username
         super().__init__(f"User not found: {self.username}")
 
 
 class LastfmAPIError(Exception):
+    """Exception for when Last.fm API sends error message as response."""
+
     def __init__(self, code: int, msg: str):
         self.code = code
         self.msg = msg
         super().__init__(f"{self.code}: {self.msg}")
+
+
+class UserLoginRequiredError(LastfmAPIError):
+    """User login required. Usually when user privates their recent scrobbles"""
+
+    def __init__(self, msg: str):
+        super().__init__(code=17, msg=msg)
+
+
+class APIKeyError(LastfmAPIError):
+    """Error related to Last.fm API Key"""
+
+    def __init__(self, code: int, msg: str):
+        super().__init__(code, msg)
+
+
+class RateLimitExceededError(LastfmAPIError):
+    """Last.fm rate limit exceeded."""
+
+    def __init__(self, msg: str):
+        super().__init__(29, msg)

--- a/src/memoryfm/io/lastfm_api.py
+++ b/src/memoryfm/io/lastfm_api.py
@@ -8,7 +8,10 @@ from zoneinfo import ZoneInfo
 
 
 from memoryfm.errors import (
+    APIKeyError,
     InvalidDataError,
+    RateLimitExceededError,
+    UserLoginRequiredError,
     UserNotFoundError,
     LastfmAPIError,
 )
@@ -200,13 +203,19 @@ def fetch_by_timestamps(
             sync_status.total_scrobbles = valid_response.total_scrobbles
             sync_status.fetched_scrobbles += len(batch)
         except LastfmAPIError as e:
-            if e.code == 8 and sync_status.retry <= sync_status.total_retries:
+            if e.code in (8, 11) and sync_status.retry <= sync_status.total_retries:
                 sync_status.retry += 1
                 sync_status.status = SyncStatusTypes.Retry
                 logger.info(format_status_log(username, sync_status))
                 continue
             elif e.code == 6:
                 raise UserNotFoundError(username)
+            elif e.code == 17:
+                raise UserLoginRequiredError(e.msg)
+            elif e.code in (10, 26):
+                raise APIKeyError(e.code, e.msg)
+            elif e.code == 29:
+                raise RateLimitExceededError(e.msg)
             else:
                 raise
         else:

--- a/src/memoryfm/models/core.py
+++ b/src/memoryfm/models/core.py
@@ -3,6 +3,7 @@ from sqlalchemy import (
     CheckConstraint,
     DateTime,
     ForeignKey,
+    Integer,
     UniqueConstraint,
     String,
     func,
@@ -148,10 +149,35 @@ class Scrobble(Base):
     track_id: Mapped[int] = mapped_column(ForeignKey("tracks.id"), index=True)
 
     user_id: Mapped[int] = mapped_column(
-        ForeignKey("users.id", ondelete="CASCADE"), doc="User id of the scrobble."
+        ForeignKey("users.id", ondelete="CASCADE"),
+        index=True,
+        doc="User id of the scrobble.",
     )
     user: Mapped["User"] = relationship(
         back_populates="scrobbles", doc="User of the scrobble in the user table."
     )
 
     __table_args__ = (UniqueConstraint("timestamp", "track_id", "user_id"),)
+
+
+class AnalyticsView(Base):
+    """
+    Read-only view for denormalized scrobbles to use for analytics.
+    """
+
+    __tablename__ = "analytics_view"
+
+    scrobble_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    timestamp: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True))
+
+    user_id: Mapped[int] = mapped_column(Integer)
+    track_id: Mapped[int] = mapped_column(Integer)
+    album_id: Mapped[int] = mapped_column(Integer)
+    artist_id: Mapped[int] = mapped_column(Integer)
+
+    track: Mapped[str] = mapped_column(String)
+    album: Mapped[str] = mapped_column(String)
+    artist: Mapped[str] = mapped_column(String)
+    username: Mapped[str] = mapped_column(String)
+
+    __table_args__ = {"info": {"is_view": True}}


### PR DESCRIPTION
## Pull Request Summary

This PR adds an analytics view to prevent duplicate joins. It also improves sync error handling using custom domain exceptions.

## Type of Change

- [x]  New Feature
- [x]  Code Refactor

## Changes

### Database

- Add an analytics view of scrobbles that includes scrobbles columns,
  and track, album, artist columns.
- Add index on user_id in scrobbles table.

### Error Handling

- Add `apply_exception_to_status` helper to centralize sync error handling.
- Catch exceptions in `run_sync`, update sync status, and log formatted errors.
- Introduce specific Last.fm exceptions:
  - `UserLoginRequiredError`
  - `APIKeyError`
  - `RateLimitExceededError`
- Map Last.fm API error codes to domain exceptions in fetch_by_timestamps.
- Extend retry logic to include additional transient error codes (8, 11).

## Checklist

- [x] Code runs without errors
- [x] Code style and lint checks passed
