### PR TITLE
web: add page header component with icon, title, and info tooltip

### DIFF
--- a/apps/web/src/components/layout/nav_sidebar/nav_items.tsx
+++ b/apps/web/src/components/layout/nav_sidebar/nav_items.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, List, Text as ChakraText} from "@chakra-ui/react";
+import { Box, Flex, List, Text as ChakraText } from "@chakra-ui/react";
 import type { IconType } from "react-icons";
 import { NavLink } from "react-router-dom";
 import { useSidebarNav } from "./nav_sidebar_context";
@@ -15,7 +15,7 @@ export interface SidebarNavItemsProps {
 }
 
 function sidebarItem(
-    item: SidebarNavItem, index: number
+  item: SidebarNavItem, index: number
 ) {
 
   const { open } = useSidebarNav();
@@ -41,17 +41,17 @@ function sidebarItem(
               {open && (
                 <ChakraText fontWeight="medium">{item.label}</ChakraText>
               )}
-      </Flex>
-    </Box>
-  )}
-</NavLink>
+            </Flex>
+          </Box>
+        )}
+      </NavLink>
     </List.Item>
   )
 }
 
 
-export default function SidebarNavItems (
-  {navItems} : SidebarNavItemsProps
+export default function SidebarNavItems(
+  { navItems }: SidebarNavItemsProps
 ) {
 
   return (
@@ -59,10 +59,10 @@ export default function SidebarNavItems (
       gap="2"
       variant={"plain"}
       width="full"
-      >
-        {navItems.map(
-          (item, index) => sidebarItem(item, index)
-        )}
-      </List.Root>
+    >
+      {navItems.map(
+        (item, index) => sidebarItem(item, index)
+      )}
+    </List.Root>
   )
 }

--- a/apps/web/src/components/pages/attachment.tsx
+++ b/apps/web/src/components/pages/attachment.tsx
@@ -6,14 +6,15 @@ import { fetchAttachmentIndex, fetchAttachmentIndexByPeriod, fetchAttachmentMome
 import { Box, Flex, parseDate, Text as ChakraText, type DateValue, VStack, Alert } from "@chakra-ui/react";
 import Section from "@/components/ui/section";
 import PeriodSelector from "@/components/features/analytics/periodselector";
-import type { AttachmentMoment, Dates, TimeSeries } from "@/typing";
+import type { AttachmentMoment, Dates, PageHeaderProps, TimeSeries } from "@/typing";
 import { useParams } from "react-router-dom";
 import KindSelector from "../features/analytics/kindselector";
 import useAnalyticsParams from "@/hooks/use_analytics_params";
 import AttachmentTimeline from "@/components/features/attachment/attachment_moments";
 import AttachmentGraph from "../features/attachment/attachment_graph";
 import { LoadingSpinner } from "../ui/loading";
-
+import { MdFavorite } from "react-icons/md";
+import PageHeader from "../ui/page-header";
 
 // Attachment Page
 
@@ -90,11 +91,18 @@ export default function AttachmentPage() {
         }
     }
 
+    const page: PageHeaderProps = {
+        title: "Attachment",
+        icon: MdFavorite,
+        info: "Attachment Index is measure of how concentrated your listening was on any given day."
+    };
+
     return (
         <Flex
             direction="column"
             gap={4}
         >
+            {PageHeader(page)}
             <Box mt={"4"}>
                 <KindSelector value={params.kind} onKindChange={setKind} />
             </Box>

--- a/apps/web/src/components/pages/overview.tsx
+++ b/apps/web/src/components/pages/overview.tsx
@@ -10,8 +10,8 @@ import { useSyncStatus } from "@/hooks/use_sync_status";
 // Components
 
 // Chakra UI components
-import { MdCalendarMonth } from "react-icons/md";
-import { Badge, Box, Flex, Icon, Separator, VStack} from "@chakra-ui/react"
+import { MdCalendarMonth, MdListAlt } from "react-icons/md";
+import { Badge, Box, Flex, Icon, Separator, VStack } from "@chakra-ui/react"
 
 // Custom Components
 import Section from "@/components/ui/section";
@@ -23,13 +23,15 @@ import TopChartsPreview from "../features/overview/topcharts_preview";
 import NoScrobbles from "../features/overview/no_scrobbles";
 import { useEffect, useState } from "react";
 import { LoadingSpinner } from "../ui/loading";
+import type { PageHeaderProps } from "@/typing";
+import PageHeader from "../ui/page-header";
 
 // Overview Page
 
-export default function Overview () {
+export default function Overview() {
     const { username } = useParams();
     const queryClient = useQueryClient();
-    
+
     const [weeks, period, limit] = [12, 30, 5];
     let isValidUsername = false;
     if (!username?.trim()) {
@@ -38,10 +40,10 @@ export default function Overview () {
     else {
         isValidUsername = true;
     }
-    
+
     const { syncStatus, isSyncActive } = useSyncStatus(username);
-    const [ showAlert, setShowAlert ] = useState<boolean>(false);
-    const [ fetched, setFetched ] = useState<number | null>(null);
+    const [showAlert, setShowAlert] = useState<boolean>(false);
+    const [fetched, setFetched] = useState<number | null>(null);
 
     const summaryQuery = useQuery({
         queryKey: ["summaryQuery", username],
@@ -71,7 +73,7 @@ export default function Overview () {
 
     const handleCloseAlert = () => {
         if (!syncStatus) return;
-        
+
         const key = `syncAlertDismissed:${username}:${syncStatus.fetched_scrobbles}`;
         localStorage.setItem(key, "true");
         setShowAlert(false);
@@ -79,7 +81,7 @@ export default function Overview () {
 
     useEffect(() => {
         if (!syncStatus) return;
-        
+
         if (syncStatus.status !== "completed") return;
 
         const key = `syncAlertDismissed:${username}:${syncStatus.fetched_scrobbles}`;
@@ -87,18 +89,18 @@ export default function Overview () {
         setTimeout(() => {
             const dismissed = localStorage.getItem(key) === "true";
             if (dismissed) return;
-            
+
             setFetched(syncStatus.fetched_scrobbles);
             setShowAlert(true);
         }, 1000);
-    
+
     }, [syncStatus?.status, syncStatus?.fetched_scrobbles, username]);
 
-  useEffect(() => {
-    queryClient.invalidateQueries({
-      queryKey: ["summaryQuery", username]
-    });
-  }, [username, queryClient]);
+    useEffect(() => {
+        queryClient.invalidateQueries({
+            queryKey: ["summaryQuery", username]
+        });
+    }, [username, queryClient]);
 
 
     if (summaryQuery.isLoading) {
@@ -122,16 +124,16 @@ export default function Overview () {
         return (
             <VStack gap={"5"}>
                 <div>
-                    { summaryQuery.error?.message}
+                    {summaryQuery.error?.message}
                 </div>
                 <div>
-                    { recentActivityQuery.error?.message }
+                    {recentActivityQuery.error?.message}
                 </div>
                 <div>
-                    { topArtistsQuery.error?.message }
+                    {topArtistsQuery.error?.message}
                 </div>
                 <div>
-                    { topTracksQuery.error?.message }
+                    {topTracksQuery.error?.message}
                 </div>
             </VStack>
         );
@@ -140,60 +142,69 @@ export default function Overview () {
 
     const { summary } = summaryQuery.data || {}
     const { from_date, to_date, counts } = recentActivityQuery.data || {}
-    const topArtistsInput = {kind: "artist", topCharts: topArtistsQuery.data}
-    const topTracksInput = {kind: "track", topCharts: topTracksQuery.data}
+    const topArtistsInput = { kind: "artist", topCharts: topArtistsQuery.data }
+    const topTracksInput = { kind: "track", topCharts: topTracksQuery.data }
+
+    const page: PageHeaderProps = {
+        title: "Overview",
+        icon: MdListAlt,
+        info: ""
+    };
 
     return (
-        <>
-        {showAlert ? (
-            <SyncCompleteAlert
-                fetched={fetched}
-                onClose={handleCloseAlert}
-            /> 
-        ) : (isSyncActive || syncStatus?.status === "error")? (
-            <SyncProgress
-                syncStatus={syncStatus!}
-            />
-        ) : null}
-        {!hasValidSummary ? (
-            <NoScrobbles
+        <Flex
+            direction="column"
+            gap={4}
+        >
+            {PageHeader(page)}
+            {showAlert ? (
+                <SyncCompleteAlert
+                    fetched={fetched}
+                    onClose={handleCloseAlert}
+                />
+            ) : (isSyncActive || syncStatus?.status === "error") ? (
+                <SyncProgress
+                    syncStatus={syncStatus!}
+                />
+            ) : null}
+            {!hasValidSummary ? (
+                <NoScrobbles
                     username={username}
                     syncStatus={syncStatus!}
                     isSyncActive={isSyncActive}
-            />
-        ) : (
-            <>
-                <Box px={{ base: 4, md: 8 }}>
-                    <VStack gap={{base: 4, md: 10 }}>
-                        <Badge
-                            bg={"purple.subtle"}
-                            color={"purple.fg"}
-                            size={"lg"}
-                            display="flex"
-                        >
-                            <Icon as={MdCalendarMonth} mr={1}></Icon>
-                            {`Scrobbling since ${summary.scrobbling_since}`}
-                        </Badge>
-                        <SummaryBadges {...summary} />
-                    </VStack>
-                </Box>
-                <Section
-                    title={"Recent Activity"}
-                    children={<RecentActivity from_date={from_date} to_date={to_date} counts={counts} />}
                 />
-                <Section
-                    title={`Top Charts - Last ${period} Days`}
-                >
-                    <Flex direction={"row"} gap="10" justify={"space-between"}>
-                        <TopChartsPreview {...topArtistsInput} />
-                        <Separator />
-                        <TopChartsPreview {...topTracksInput} />
-                    </Flex>
-                </Section>
-            </>
-        )}
-        </>
+            ) : (
+                <>
+                    <Box px={{ base: 4, md: 8 }}>
+                        <VStack gap={{ base: 4, md: 10 }}>
+                            <Badge
+                                bg={"purple.subtle"}
+                                color={"purple.fg"}
+                                size={"lg"}
+                                display="flex"
+                            >
+                                <Icon as={MdCalendarMonth} mr={1}></Icon>
+                                {`Scrobbling since ${summary.scrobbling_since}`}
+                            </Badge>
+                            <SummaryBadges {...summary} />
+                        </VStack>
+                    </Box>
+                    <Section
+                        title={"Recent Activity"}
+                        children={<RecentActivity from_date={from_date} to_date={to_date} counts={counts} />}
+                    />
+                    <Section
+                        title={`Top Charts - Last ${period} Days`}
+                    >
+                        <Flex direction={"row"} gap="10" justify={"space-between"}>
+                            <TopChartsPreview {...topArtistsInput} />
+                            <Separator />
+                            <TopChartsPreview {...topTracksInput} />
+                        </Flex>
+                    </Section>
+                </>
+            )}
+        </Flex>
     );
 }
 
-    

--- a/apps/web/src/components/pages/streaks.tsx
+++ b/apps/web/src/components/pages/streaks.tsx
@@ -4,7 +4,7 @@ import { fetchStreaksByYear } from "@/api/analytics";
 import { useQuery } from "@tanstack/react-query";
 import useAnalyticsParams, { useYearRange } from "@/hooks/use_analytics_params";
 
-import type { ListeningStreak } from "@/typing";
+import type { ListeningStreak, PageHeaderProps } from "@/typing";
 
 import { Box, Flex, Text as ChakraText, VStack, Alert } from "@chakra-ui/react";
 import SliderSelector from "@/components/features/analytics/sliderselector";
@@ -12,6 +12,8 @@ import KindSelector from "@/components/features/analytics/kindselector";
 import StreaksTimeline from "@/components/features/streaks/streaks_timeline";
 import Section from "../ui/section";
 import { LoadingSpinner } from "../ui/loading";
+import { MdBolt } from "react-icons/md";
+import PageHeader from "../ui/page-header";
 
 
 export default function StreaksPage() {
@@ -60,11 +62,18 @@ export default function StreaksPage() {
 
     const streaks: ListeningStreak[] = streaksQuery.data || []
 
+    const page: PageHeaderProps = {
+        title: "Streaks",
+        icon: MdBolt,
+        info: "A Streak is a series of consecutive listens of the same artist, album, or track."
+    };
+
     return (
         <Flex
             direction="column"
             gap={4}
         >
+            {PageHeader(page)}
             <Box mt={"4"}>
                 <KindSelector value={params.kind} onKindChange={setKind} />
             </Box>

--- a/apps/web/src/components/pages/topcharts.tsx
+++ b/apps/web/src/components/pages/topcharts.tsx
@@ -7,7 +7,7 @@ import { Box, Flex, parseDate, Text as ChakraText, type DateValue, VStack, Alert
 //import Section from "@/components/ui/section";
 import { fetchTopChartsByPeriod } from "@/api/user";
 import PeriodSelector from "@/components/features/analytics/periodselector";
-import type { Dates, TopChart } from "@/typing";
+import type { Dates, PageHeaderProps, TopChart } from "@/typing";
 import { useParams } from "react-router-dom";
 import KindSelector from "../features/analytics/kindselector";
 import useAnalyticsParams from "@/hooks/use_analytics_params";
@@ -15,6 +15,8 @@ import LimitSelector from "../features/analytics/limitselector";
 import TopChartsTable from "../features/topcharts/topcharts_table";
 import Section from "../ui/section";
 import { LoadingSpinner } from "../ui/loading";
+import { MdBarChart } from "react-icons/md";
+import PageHeader from "../ui/page-header";
 
 // Top Charts Page
 
@@ -80,12 +82,19 @@ export default function TopChartsPage() {
         }
     }
 
+    const page: PageHeaderProps = {
+        title: "Top Charts",
+        icon: MdBarChart,
+        info: ""
+    };
+
 
     return (
         <Flex
             direction="column"
             gap={4}
         >
+            {PageHeader(page)}
             <Box mt={"4"}>
                 <KindSelector value={params.kind} onKindChange={setKind} />
             </Box>

--- a/apps/web/src/components/ui/page-header.tsx
+++ b/apps/web/src/components/ui/page-header.tsx
@@ -1,0 +1,38 @@
+import { HStack, Text as ChakraText, IconButton, Flex, Box } from "@chakra-ui/react"
+import { MdInfo } from "react-icons/md"
+import { Tooltip } from "./tooltip"
+import type { PageHeaderProps } from "@/typing"
+
+export default function PageHeader(
+    page: PageHeaderProps
+) {
+    return (
+        <HStack gap={0} align={"top"} justify={"center"} mb={"6"}>
+            <Flex align="center" gap="2">
+                <Box fontSize="2xl"><page.icon /></Box>
+                <ChakraText
+                    fontWeight="bold"
+                    fontSize={"2xl"}
+                    textTransform={"uppercase"}
+                    letterSpacing={"widest"}
+                >
+                    {page.title}
+                </ChakraText>
+            </Flex>
+            {page.info.length>0 && (<Tooltip
+                content={page.info}
+                interactive
+            >
+                <IconButton
+                    variant="plain"
+                    color="fg.subtle"
+                    size="xs"
+                    aria-label="Attachment Index Info"
+                >
+                    <MdInfo />
+                </IconButton>
+            </Tooltip>
+            )}
+        </HStack>
+    )
+}

--- a/apps/web/src/typing.ts
+++ b/apps/web/src/typing.ts
@@ -1,6 +1,7 @@
 // Types and Interfaces
 
 import type { DateValue } from "@chakra-ui/react";
+import type { IconType } from "react-icons";
 
 export interface TopChart {
     name: string,
@@ -66,4 +67,10 @@ export type ListeningStreak = {
   length: number
   log_length: number
   kind: KindType
+}
+
+export type PageHeaderProps = {
+  title: string
+  icon: IconType
+  info: string
 }


### PR DESCRIPTION
## Pull Request Summary

This PR adds a `PageHeader` component to display header to each page, with icon, title, and optional info tooltip. It also implements the `PageHeader` in each of these pages:
- Overview
- Top Charts
- Attachment
- Streaks

## Type of Change

- [x]  New Feature

## Changes

### Web App

- Add `PageHeader` component with an icon, page title, and page info.
- Add `PageHeaderProps` type to handle `PageHeader` input values.
- Add page headers to all pages: Overview, Top Charts, Attachment, Streaks.
- Show info tooltip in header on Attachment and Streaks pages.
