### PR TITLE
bug: fix attachment moments internal server error bug and add regression test for threshold filtering

### DIFF
--- a/src/memoryfm/services/attachment_service.py
+++ b/src/memoryfm/services/attachment_service.py
@@ -124,11 +124,18 @@ def get_attachment_moments(
             top_charts_df = pd.DataFrame(top_charts)
             df["z_score"] = (df["value"] - df["value"].mean()) / df["value"].std()
 
-            top_moments_df = df[df["z_score"] >= threshold]
+            top_moments_df = df[df["z_score"] >= threshold].copy()
+
+            if top_moments_df.empty:
+                return []
+
             top_moments_df["day"] = top_moments_df["day"].dt.strftime("%Y-%m-%d")
-            top_moments_df[["name", "scrobbles", "total_scrobbles"]] = top_charts_df[
-                ["name", "scrobbles", "total_scrobbles"]
-            ]
+            top_charts_df["day"] = top_charts_df["day"].dt.strftime("%Y-%m-%d")
+            top_moments_df = top_moments_df.merge(
+                top_charts_df[["day", "name", "scrobbles", "total_scrobbles"]],
+                on="day",
+                how="left",
+            )
             top_moments_df["dominance"] = (
                 top_moments_df["scrobbles"] / top_moments_df["total_scrobbles"]
             )

--- a/tests/services/test_attachment.py
+++ b/tests/services/test_attachment.py
@@ -89,8 +89,15 @@ def test_get_weighted_attachment_index(seeded_db: Session):
 
 def test_get_attachment_moments(seeded_db: Session):
     moments = attserv.get_attachment_moments(
-        seeded_db, username, kind, from_ts, to_ts, freq=Frequency.D
+        seeded_db, username, kind, from_ts, to_ts, freq=Frequency.D, threshold=0
     )
     assert moments is not None
-    assert len(moments) == 2
-    assert moments[1].get("name") == "Anything We Want"
+    assert len(moments) == 1, repr(moments)
+    assert moments[0].get("name") == "Anything We Want"
+
+
+def test_get_attachment_moments_empty(seeded_db: Session):
+    moments = attserv.get_attachment_moments(
+        seeded_db, username, kind, from_ts, to_ts, freq=Frequency.D, threshold=1000
+    )
+    assert moments == []


### PR DESCRIPTION
## Pull Request Summary

This PR fixes internal server error bug when fetching attachment moments when there are no moments in the period that are above the threshold.

This occurs due to index based assignment to `top_moments_df` when `top_moments_df` is empty due to threshold condition, which cause nan values and Validation Error in the FastAPI endpoint.

This is fixed by:
- returning empty list when `top_moments_df` is empty, and
- replacing index-based assignment with an explicit merge on day.

## Related Issues

Closes #97

## Type of Change

- [x]  Bugfix
- [x]  Tests

## Problem

Previously, after filtering by threshold,

```py
top_moments_df = df[df["z_score"] >= threshold]
```
the code assigned columns like this:

```py
top_moments_df[["name", "scrobbles", "total_scrobbles"]] = top_charts_df[...]
```

But if `top_moments_df` is empty, this causes nan values and Validation Error in the FastAPI endpoint.


## Fix

Return empty list when `top_moments_df` is empty, and replace index-based assignment with an explicit merge on day.

```py
top_moments_df = df[df["z_score"] >= threshold].copy()

if top_moments_df.empty:
    return []

top_moments_df["day"] = top_moments_df["day"].dt.strftime("%Y-%m-%d")
top_charts_df["day"] = top_charts_df["day"].dt.strftime("%Y-%m-%d")
top_moments_df = top_moments_df.merge(
    top_charts_df[["day", "name", "scrobbles", "total_scrobbles"]],
    on="day",
    how="left",
)
```

## Tests

- Add regression test for threshold filtering returning empty results
- Update existing test to reflect corrected merge-based behavior

## Checklist

- [x] Code runs without errors
- [x] Tests added/updated and passed.
- [x] Code style and lint checks passed
