### PR TITLE
enh: use last.fm API to check if user exists before creating

### DIFF
--- a/apps/api/routers/user.py
+++ b/apps/api/routers/user.py
@@ -14,6 +14,7 @@ from apps.api.response_models import (
     SummaryModel,
     YearRange,
 )
+from memoryfm.models.service_helpers import LastfmUserInfoResponse
 from memoryfm.storage.session import get_db_session
 import memoryfm.services.stats_service as stserv
 from memoryfm.services.scrobble_service import get_year_range
@@ -25,15 +26,17 @@ load_dotenv()
 API_KEY = os.getenv("API_KEY", "")
 
 
-@router.post("/user/{username}/ensure")
+@router.post(
+    "/user/{username}/ensure",
+    response_model=LastfmUserInfoResponse,
+)
 async def ensure_user(
     username: TrimmedStr,
-    bg_tasks: BackgroundTasks,
     session=Depends(get_db_session),
 ):
     """Ensure that user with username exist. If not, create one."""
-    bg_tasks.add_task(run_ensure_user, session, username)
-    return {"status": "accepted", "message": f"Ensure user task started for {username}"}
+    userinfo = await run_ensure_user(session, username, api_key=API_KEY)
+    return userinfo
 
 
 @router.post("/user/{username}/sync")

--- a/apps/api/state/sync.py
+++ b/apps/api/state/sync.py
@@ -3,10 +3,17 @@ import logging
 from typing import TYPE_CHECKING
 import asyncio
 
+from fastapi.responses import JSONResponse
+
 from apps.api.state.status_services import get_sync_status, get_ensure_user_status
 from apps.api.state.locks import get_lock
 from memoryfm.io.lastfm_api import sync_lastfm_api, refresh_scrobbles_lastfm_api
-from memoryfm.models.sync_status import SyncStatus, SyncStatusTypes
+from memoryfm.models.sync_status import (
+    EnsureUserStatus,
+    SyncStatus,
+    SyncStatusTypes,
+    UserExist,
+)
 from memoryfm.services.user_service import ensure_user
 from memoryfm.util.format_sync_log import format_status_log
 import memoryfm.errors as err
@@ -34,6 +41,24 @@ def apply_exception_to_status(e: Exception, sync_status: SyncStatus):
         sync_status.error = str(e)
 
 
+def apply_exception_to_ensure_status(
+    e: Exception, ensure_user_status: EnsureUserStatus
+):
+    ensure_user_status.status = UserExist.Checking
+
+    if isinstance(
+        e,
+        (
+            err.LastfmAPIError,
+            err.APIKeyError,
+            err.RateLimitExceededError,
+        ),
+    ):
+        ensure_user_status.error = e.msg
+    else:
+        ensure_user_status.error = str(e)
+
+
 async def run_sync(session: Session, username: str, api_key: str):
     sync_status = get_sync_status(username)
     lock = get_lock(username)
@@ -53,17 +78,40 @@ async def run_sync(session: Session, username: str, api_key: str):
             logger.error(format_status_log(username, sync_status))
 
 
-async def run_ensure_user(session: Session, username: str):
+async def run_ensure_user(session: Session, username: str, api_key: str):
     ensure_sync_status = get_ensure_user_status(username)
     lock = get_lock(username)
 
     async with lock:
-        await asyncio.to_thread(
-            ensure_user,
-            session,
-            username,
-            ensure_sync_status,
-        )
+        ensure_sync_status.error = None
+        try:
+            userinfo = await asyncio.to_thread(
+                ensure_user,
+                session,
+                username,
+                api_key,
+                ensure_sync_status,
+            )
+            return userinfo
+        except Exception as e:
+            logger.error(str(e))
+            if isinstance(
+                e,
+                (
+                    err.LastfmAPIError,
+                    err.APIKeyError,
+                    err.RateLimitExceededError,
+                ),
+            ):
+                ensure_sync_status.error = e.msg
+                errors = [{"code": e.code, "msg": e.msg}]
+
+            elif isinstance(e, err.UserNotFoundError):
+                ensure_sync_status.error = str(e)
+                errors = [{"code": 6, "msg": str(e)}]
+            else:
+                errors = [{"code": 31, "msg": str(e)}]
+            return JSONResponse(status_code=422, content={"errors": errors})
 
 
 async def run_refresh(session: Session, username: str, api_key: str):

--- a/apps/web/src/api/user.ts
+++ b/apps/web/src/api/user.ts
@@ -5,15 +5,19 @@ export const handleResponse = async (res: Response) => {
   const data = await res.json();
 
   if (!res.ok) {
-    if (res.status === 422 && data.errors) {
-      const errorMessages = data.errors
-        .map((err: { msg: string }, i: number) => `${i} - ${err.msg}`)
-        .join(", ");
+    const error: any = new Error();
+    error.status = res.status;
+    error.data = data;
 
-      throw new Error(errorMessages);
+    if (res.status === 422 && data.errors) {
+      error.message = data.errors
+        .map((err: { msg: string }) => `${err.msg}`)
+        .join("\n");
+    } else {
+      throw new Error(data.message || "Request failed");
     }
 
-    throw new Error(data.message || "Request failed");
+    throw error;
   }
 
   return data;

--- a/apps/web/src/components/pages/homepage.tsx
+++ b/apps/web/src/components/pages/homepage.tsx
@@ -2,15 +2,18 @@ import { useState, type ChangeEvent, type FormEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ensureUser } from '@/api/user';
 
-import { Box, Button, VStack, Input, Center, Container, Text as ChakraText, Heading } from '@chakra-ui/react'
+import { Box, Button, VStack, Input, Center, Container, Text as ChakraText, Heading, Field } from '@chakra-ui/react'
 
 function HomePage() {
   const [username, setUsername] = useState("");
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   const navigate = useNavigate();
   const normalizedUsername = username.trim();
 
-  function handleChange (event: ChangeEvent<HTMLInputElement>) {
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    setError(null);
     setUsername(event.target.value);
   }
 
@@ -21,12 +24,15 @@ function HomePage() {
 
     try {
       setLoading(true);
+      setError(null);
 
       await ensureUser(normalizedUsername);
 
       navigate(`/user/${normalizedUsername}/overview`);
-    } catch (err) {
+    } catch (err: any) {
       console.error("Failed to ensure user exists.", err);
+
+      setError(err.message);
     } finally {
       setLoading(false);
     }
@@ -49,6 +55,7 @@ function HomePage() {
           {/* Form Section */}
           <Box as="form" onSubmit={handleSubmit} w="full">
             <VStack gap="6">
+              <Field.Root invalid={!!error}>
               <Input
                 autoFocus
                 value={username}
@@ -61,7 +68,14 @@ function HomePage() {
                 disabled={loading}
                 _focus={{ borderColor: "accent" }}
               />
-              
+              </Field.Root>
+
+              {error && (
+                <ChakraText color="red.400" fontSize="sm">
+                  {error}
+                </ChakraText>
+              )}
+
               <Button
                 size="xl"
                 w="full"

--- a/src/memoryfm/models/service_helpers.py
+++ b/src/memoryfm/models/service_helpers.py
@@ -69,9 +69,25 @@ class LastfmErrorResponse(BaseModel):
     msg: str = Field(validation_alias=AliasPath("message"))
 
 
+class LastfmUserInfoResponse(BaseModel):
+    name: str = Field(validation_alias=AliasPath("user", "name"))
+    url: str = Field(validation_alias=AliasPath("user", "url"))
+
+
 def parse_lastfm_api_response(response_data: Any) -> LastfmResponse:
     try:
         return LastfmResponse.model_validate(response_data)
+    except ValidationError:
+        try:
+            error_data = LastfmErrorResponse.model_validate(response_data).model_dump()
+            raise LastfmAPIError(**error_data)
+        except ValidationError:
+            raise
+
+
+def parse_lastfm_api_user_info(response_data: Any) -> LastfmUserInfoResponse:
+    try:
+        return LastfmUserInfoResponse.model_validate(response_data)
     except ValidationError:
         try:
             error_data = LastfmErrorResponse.model_validate(response_data).model_dump()

--- a/src/memoryfm/models/sync_status.py
+++ b/src/memoryfm/models/sync_status.py
@@ -46,6 +46,9 @@ class UserExist(Enum):
 @dataclass
 class EnsureUserStatus:
     status: UserExist | None = None
+    retry: int | None = None
+    total_retries: int | None = None
+    error: str | None = None
 
     def to_dict(self):
         return serialize(asdict(self))

--- a/src/memoryfm/services/user_service.py
+++ b/src/memoryfm/services/user_service.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
+import json
 from typing import TYPE_CHECKING
 import logging
+from pydantic import ValidationError
+import requests
 from sqlalchemy.exc import SQLAlchemyError
 import memoryfm.storage.user_repo as urepo
 from memoryfm.util.datetime_util import validate_tz
-from memoryfm.errors import UserNotFoundError
-from memoryfm.models.service_helpers import UserContext
+from memoryfm.errors import (
+    APIKeyError,
+    InvalidDataError,
+    LastfmAPIError,
+    RateLimitExceededError,
+    UserNotFoundError,
+)
+from memoryfm.models.service_helpers import UserContext, parse_lastfm_api_user_info
 from memoryfm.models.sync_status import UserExist
 
 if TYPE_CHECKING:
@@ -54,11 +63,59 @@ def get_user_context(session: Session, username: str) -> UserContext:
         raise UserNotFoundError(username)
 
 
-def ensure_user(session: Session, username: str, ensure_user_status: EnsureUserStatus):
-    ensure_user_status.status = UserExist.Checking
+def lastfm_get_user_info(
+    username: str,
+    api_key: str,
+):
+    """
+    Fetch user info from last.fm API method user.getInfo
+    Parameters
+    ----------
+    username : str
+        A last.fm username.
+    api_key : str
+        A valid last.fm API key
+
+    """
+    url = f"http://ws.audioscrobbler.com/2.0/?method=user.getinfo&user={username}&api_key={api_key}&format=json"
+    response = requests.get(url)
     try:
-        create_user(session, username)
-        ensure_user_status.status = UserExist.Exists
-    except Exception as e:
-        ensure_user_status.status = UserExist.Error
-        raise UserNotFoundError(username, *e.args)
+        response_data = response.json()
+        return parse_lastfm_api_user_info(response_data)
+    except json.JSONDecodeError:
+        raise
+    except InvalidDataError:
+        raise
+    except ValidationError:
+        raise
+
+
+def ensure_user(
+    session: Session, username: str, api_key: str, ensure_user_status: EnsureUserStatus
+):
+    ensure_user_status.status = UserExist.Checking
+    ensure_user_status.retry = 1
+    ensure_user_status.total_retries = 5
+    while True:
+        try:
+            userinfo = lastfm_get_user_info(username, api_key)
+            create_user(session, username)
+            ensure_user_status.status = UserExist.Exists
+            return userinfo
+        except LastfmAPIError as e:
+            ensure_user_status.status = UserExist.Error
+            if (
+                e.code in (8, 11)
+                and ensure_user_status.retry <= ensure_user_status.total_retries
+            ):
+                ensure_user_status.retry += 1
+                continue
+            elif e.code == 6:
+                raise UserNotFoundError(username)
+            elif e.code in (10, 26):
+                raise APIKeyError(e.code, e.msg)
+            elif e.code == 29:
+                raise RateLimitExceededError(e.msg)
+        except Exception as e:
+            ensure_user_status.status = UserExist.Error
+            raise UserNotFoundError(username, *e.args)


### PR DESCRIPTION
## Pull Request Summary

This PR makes on-boarding user more robust and protects the database by making sure user exists on Last.fm before adding to the database. It also updates the front-end to show error in case user doesn't exist.

## Type of Change

- [x]  New Feature
- [x]  Code Refactor

## Changes

### Back-end Services

- Add back-end function to fetch user info from Last.fm API.
- Add response model and helper to parse last.fm user info response.
- Add retry and total_retries attributes to `EnsureUserStatus` model.
- Update `ensure_user` service to check if user exists using the user info function before creating in database.
- Handle domain LastfmAPIErrors.

### Back-end API

- Update ensure endpoint to be normal async method instead of background task.
- If there's an error, send structured error as response with 422 status code.

### Web UI

- Update frontend method `handleResponse` to correctly handle error response.
- Update frontend homepage to show error if user doesn't exist.

## Checklist

- [x] Code runs without errors
- [x] Tests added/updated and passed.
- [x] Code style and lint checks passed
