### PR TITLE
enh: refactor analytics services to fetch data from AnalyticsView instead of the scrobbles table.

### DIFF
--- a/apps/api/response_models.py
+++ b/apps/api/response_models.py
@@ -5,6 +5,7 @@ from datetime import date, datetime
 from math import log2
 
 from memoryfm.models.service_enums import ChartKindColumn
+from memoryfm.storage.streaks import StreakType
 
 
 class ScrobblesCount(BaseModel):
@@ -87,19 +88,22 @@ class ListeningStreak(BaseModel):
     start: datetime
     end: datetime
     name: str
+    subname: str | None
     length: int
     log_length: float
     kind: ChartKindColumn
 
     @classmethod
-    def from_service_data(
-        cls, kind: ChartKindColumn, data: tuple[datetime, datetime, str, int] | None
-    ):
-        schema = TypeAdapter(tuple[datetime, datetime, str, int])
+    def from_service_data(cls, kind: ChartKindColumn, data: StreakType | None):
+        schema = TypeAdapter(StreakType)
         if not data:
             raise ResponseValidationError(errors=[{"msg": "No data found for user."}])
         try:
-            start, end, name, length = schema.validate_python(data)
+            if kind.subname_column is not None:
+                start, end, name, length, subname = schema.validate_python(data)
+            else:
+                start, end, name, length = schema.validate_python(data)
+                subname = None
         except ValidationError as e:
             raise ResponseValidationError(errors=e.errors())
         log_length = log2(length)
@@ -107,6 +111,7 @@ class ListeningStreak(BaseModel):
             start=start,
             end=end,
             name=name,
+            subname=subname,
             length=length,
             log_length=log_length,
             kind=kind,

--- a/src/memoryfm/models/service_enums.py
+++ b/src/memoryfm/models/service_enums.py
@@ -1,6 +1,7 @@
-from __future__ import annotations
 from enum import Enum
-from memoryfm.models.core import Scrobble
+from sqlalchemy.orm import InstrumentedAttribute
+
+from memoryfm.models.core import AnalyticsView, Scrobble
 
 
 class ChartKindColumn(Enum):
@@ -14,6 +15,33 @@ class ChartKindColumn(Enum):
             "artist": Scrobble.artist,
             "album": Scrobble.album,
             "track": Scrobble.track,
+        }
+        return mapping[self.value]
+
+    @property
+    def id_column(self) -> InstrumentedAttribute[int]:
+        mapping = {
+            "artist": AnalyticsView.artist_id,
+            "album": AnalyticsView.album_id,
+            "track": AnalyticsView.track_id,
+        }
+        return mapping[self.value]
+
+    @property
+    def name_column(self) -> InstrumentedAttribute[str]:
+        mapping = {
+            "artist": AnalyticsView.artist,
+            "album": AnalyticsView.album,
+            "track": AnalyticsView.track,
+        }
+        return mapping[self.value]
+
+    @property
+    def subname_column(self) -> InstrumentedAttribute[str] | None:
+        mapping: dict[str, InstrumentedAttribute[str] | None] = {
+            "artist": None,
+            "album": AnalyticsView.artist,
+            "track": AnalyticsView.artist,
         }
         return mapping[self.value]
 

--- a/src/memoryfm/services/attachment_service.py
+++ b/src/memoryfm/services/attachment_service.py
@@ -131,8 +131,11 @@ def get_attachment_moments(
 
             top_moments_df["day"] = top_moments_df["day"].dt.strftime("%Y-%m-%d")
             top_charts_df["day"] = top_charts_df["day"].dt.strftime("%Y-%m-%d")
+            merge_cols = ["day", "name", "scrobbles", "total_scrobbles"]
+            if "subname" in top_charts_df.columns:
+                merge_cols.append("subname")
             top_moments_df = top_moments_df.merge(
-                top_charts_df[["day", "name", "scrobbles", "total_scrobbles"]],
+                top_charts_df[merge_cols],
                 on="day",
                 how="left",
             )

--- a/src/memoryfm/storage/cte_util.py
+++ b/src/memoryfm/storage/cte_util.py
@@ -2,7 +2,7 @@ import datetime
 
 from sqlalchemy import CTE, Float, func, select
 
-from memoryfm.models.core import Scrobble
+from memoryfm.models.core import AnalyticsView
 from memoryfm.models.service_enums import ChartKindColumn, Frequency
 
 
@@ -13,29 +13,43 @@ def get_frequency_cte(
     to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
 ) -> CTE:
-    stmt_bin = select(
-        func.date_trunc(freq.value, Scrobble.timestamp).label(freq.value),
-        kind.column,
-    ).where(Scrobble.user_id == user_id)
+    id_col = kind.id_column.label("id")  # type: ignore[attr-defined]
+    name_col = kind.name_column.label("name")  # type: ignore[attr-defined]
+    subname_col = kind.subname_column.label("subname") if kind.subname_column else None  # type: ignore[attr-defined]
+    date_col = func.date_trunc(freq.value, AnalyticsView.timestamp).label(freq.value)
+
+    if subname_col is not None:
+        stmt = select(date_col, id_col, name_col, subname_col)
+    else:
+        stmt = select(date_col, id_col, name_col)
+
+    stmt_bin = stmt.where(AnalyticsView.user_id == user_id)
+
     if from_ts:
-        stmt_bin = stmt_bin.filter(Scrobble.timestamp >= from_ts)
+        stmt_bin = stmt_bin.filter(AnalyticsView.timestamp >= from_ts)
     if to_ts:
-        stmt_bin = stmt_bin.filter(Scrobble.timestamp < to_ts)
+        stmt_bin = stmt_bin.filter(AnalyticsView.timestamp <= to_ts)
 
     stmt_cte_bin = stmt_bin.cte("binned")
 
-    stmt_cte_freq = (
-        select(
-            stmt_cte_bin.columns[freq.value],
-            stmt_cte_bin.columns[kind.value],
-            func.count().cast(Float).label("scrobbles"),
-        )
-        .group_by(
-            stmt_cte_bin.columns[freq.value],
-            stmt_cte_bin.columns[kind.value],
-        )
-        .cte("freq")
+    columns_new = (
+        stmt_cte_bin.columns[freq.value],
+        stmt_cte_bin.columns["id"],
+        func.any_value(stmt_cte_bin.columns["name"]).label("name"),
+        func.count().cast(Float).label("scrobbles"),
     )
+    if subname_col is not None:
+        stmt = select(
+            *columns_new,
+            func.any_value(stmt_cte_bin.columns["subname"]).label("subname"),
+        )
+    else:
+        stmt = select(*columns_new)
+
+    stmt_cte_freq = stmt.group_by(
+        stmt_cte_bin.columns[freq.value],
+        stmt_cte_bin.columns["id"],
+    ).cte("freq")
     return stmt_cte_freq
 
 
@@ -52,10 +66,19 @@ def get_frequency_proportions_cte(
     total_scrobbles_col = func.sum(scrobbles_col).over(
         partition_by=cte_freq_cols[freq.value]
     )
-    stmt_cte_props = select(
+
+    columns = (
         cte_freq_cols[freq.value],
-        cte_freq_cols[kind.value],
+        cte_freq_cols["id"],
+        cte_freq_cols["name"],
         total_scrobbles_col.label("total_scrobbles"),
         (scrobbles_col / total_scrobbles_col).label("prop"),
-    ).cte("props")
+    )
+
+    if kind.subname_column is not None:
+        stmt_cte_props = select(*columns, cte_freq_cols["subname"]).cte("props")
+    else:
+        stmt_cte_props = select(*columns).cte("props")
+
+    stmt_cte_props = select(*columns).cte("props")
     return stmt_cte_props

--- a/src/memoryfm/storage/stats_repo.py
+++ b/src/memoryfm/storage/stats_repo.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 import datetime
 from sqlalchemy import desc, distinct, select, func
-from memoryfm.models.core import Scrobble
+from memoryfm.models.core import AnalyticsView
 from memoryfm.models.service_enums import Frequency
 from memoryfm.storage.user_repo import get_user_by_id
 from memoryfm.storage.cte_util import get_frequency_cte
@@ -17,20 +17,22 @@ if TYPE_CHECKING:
 def get_summary_by_user(session: Session, user_id: int) -> dict | None:
     user = get_user_by_id(session, user_id)
     username = user.username if user else None
-    data = (
-        session.execute(
-            select(
-                func.count(Scrobble.id).label("count"),
-                func.min(Scrobble.timestamp).label("first_scrobble"),
-                func.max(Scrobble.timestamp).label("last_scrobble"),
-                func.count(distinct(Scrobble.track)).label("tracks"),
-                func.count(distinct(Scrobble.artist)).label("artists"),
-                func.count(distinct(Scrobble.album)).label("albums"),
-            ).where(Scrobble.user_id == user_id)
-        )
-        .mappings()
-        .fetchone()
+
+    columns = (
+        func.count(AnalyticsView.scrobble_id).label("count"),
+        func.min(AnalyticsView.timestamp).label("first_scrobble"),
+        func.max(AnalyticsView.timestamp).label("last_scrobble"),
+        func.count(distinct(AnalyticsView.track_id)).label("tracks"),
+        func.count(distinct(AnalyticsView.artist_id)).label("artists"),
+        func.count(distinct(AnalyticsView.album_id))
+        .filter(AnalyticsView.album != "")
+        .label("albums"),
     )
+    conditions = [AnalyticsView.user_id == user_id]
+    stmt = select(*columns).where(*conditions)
+
+    data = session.execute(stmt).mappings().fetchone()
+
     if data:
         first_date: datetime.datetime | None = data.get("first_scrobble")
         last_date: datetime.datetime | None = data.get("last_scrobble")
@@ -63,18 +65,26 @@ def get_top_charts_by_user(
     to_ts: datetime.datetime | None = None,
     limit: int | None = 10,
 ) -> Sequence[RowMapping]:
-    col = kind.column
-    stmt = (
-        select(col.label("name"), func.count(Scrobble.id).label("scrobbles"))
-        .where(Scrobble.user_id == user_id)
-        .group_by("name")
-        .order_by(desc("scrobbles"), desc(func.max(Scrobble.timestamp)))
-        .limit(limit)
-    )
+    id_col = kind.id_column.label("id")  # type: ignore[attr-defined]
+    name_col = func.any_value(kind.name_column).label("name")
+    subname_col = func.any_value(kind.subname_column).label("subname")
+    scrobbles_col = func.count(AnalyticsView.scrobble_id).label("scrobbles")
+
+    stmt = select(id_col, name_col, scrobbles_col)
+    if subname_col is not None:
+        stmt = select(id_col, name_col, subname_col, scrobbles_col)
+
+    conditions = (AnalyticsView.user_id == user_id,)
+    groupby = (id_col,)
+    orderby = (desc(scrobbles_col), desc(func.max(AnalyticsView.timestamp)))
+
+    stmt = stmt.where(*conditions).group_by(*groupby).order_by(*orderby).limit(limit)
+
     if from_ts:
-        stmt = stmt.filter(Scrobble.timestamp >= from_ts)
+        stmt = stmt.filter(AnalyticsView.timestamp >= from_ts)
     if to_ts:
-        stmt = stmt.filter(Scrobble.timestamp < to_ts)
+        stmt = stmt.filter(AnalyticsView.timestamp <= to_ts)
+
     top = session.execute(stmt).mappings().fetchall()
     return top
 
@@ -88,19 +98,21 @@ def get_daily_scrobbles_count(
     datelimit = till if till else datetime.date.today()
     to_date = datelimit
     from_date = to_date - datetime.timedelta(days=limit)
-    stmt = (
-        select(
-            func.date(Scrobble.timestamp).label("Date"),
-            func.count(Scrobble.id).label("Scrobbles"),
-        )
-        .where(
-            Scrobble.user_id == user_id,
-            func.date(Scrobble.timestamp) <= to_date,
-            func.date(Scrobble.timestamp) >= from_date,
-        )
-        .order_by(desc("Date"))
-        .group_by("Date")
-    )
+
+    date_col = func.date(AnalyticsView.timestamp)
+    columns = [
+        date_col.label("Date"),
+        func.count(AnalyticsView.scrobble_id).label("Scrobbles"),
+    ]
+    conditions = [
+        AnalyticsView.user_id == user_id,
+        func.date(AnalyticsView.timestamp) <= to_date,
+        func.date(AnalyticsView.timestamp) >= from_date,
+    ]
+    orderby = (desc(date_col),)
+    groupby = (date_col,)
+    stmt = select(*columns).where(*conditions).order_by(*orderby).group_by(*groupby)
+
     data = session.execute(stmt).mappings().all()
     return from_date, to_date, data
 

--- a/src/memoryfm/storage/stats_repo.py
+++ b/src/memoryfm/storage/stats_repo.py
@@ -67,11 +67,11 @@ def get_top_charts_by_user(
 ) -> Sequence[RowMapping]:
     id_col = kind.id_column.label("id")  # type: ignore[attr-defined]
     name_col = func.any_value(kind.name_column).label("name")
-    subname_col = func.any_value(kind.subname_column).label("subname")
     scrobbles_col = func.count(AnalyticsView.scrobble_id).label("scrobbles")
 
     stmt = select(id_col, name_col, scrobbles_col)
-    if subname_col is not None:
+    if kind.subname_column is not None:
+        subname_col = func.any_value(kind.subname_column).label("subname")
         stmt = select(id_col, name_col, subname_col, scrobbles_col)
 
     conditions = (AnalyticsView.user_id == user_id,)
@@ -127,17 +127,25 @@ def get_top_charts_by_freq(
 ) -> Sequence[RowMapping]:
     stmt_cte_freq = get_frequency_cte(user_id, kind, from_ts, to_ts, freq)
     cols = stmt_cte_freq.columns
+    freq_col = cols[freq.value]
     scrobbles_col = cols["scrobbles"]
-    total_scrobbles_col = func.sum(scrobbles_col).over(partition_by=cols[freq.value])
-    stmt = (
-        select(
-            cols[freq.value].label("day"),
-            cols[kind.value].label("name"),
-            cols["scrobbles"],
-            total_scrobbles_col.label("total_scrobbles"),
-        )
-        .distinct(cols[freq.value])
-        .order_by(cols[freq.value], desc(cols["scrobbles"]))
+    total_scrobbles_col = (
+        func.sum(scrobbles_col).over(partition_by=freq_col).label("total_scrobbles")
     )
+
+    select_columns = (
+        freq_col.label("day"),
+        cols["id"],
+        cols["name"],
+        scrobbles_col,
+        total_scrobbles_col,
+    )
+
+    if "subname" in cols:
+        stmt = select(*select_columns, cols["subname"])
+    else:
+        stmt = select(*select_columns)
+
+    stmt = stmt.distinct(freq_col).order_by(freq_col, desc(cols["scrobbles"]))
     top = session.execute(stmt).mappings().fetchall()
     return top

--- a/src/memoryfm/storage/streaks.py
+++ b/src/memoryfm/storage/streaks.py
@@ -5,9 +5,15 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 import numpy as np
 
-from memoryfm.models.core import Scrobble
+from memoryfm.models.core import AnalyticsView
 from memoryfm.models.service_enums import ChartKindColumn
 from memoryfm._cython._streaks import streak_gen
+
+
+StreakType = (
+    tuple[datetime.datetime, datetime.datetime, str, int, str]
+    | tuple[datetime.datetime, datetime.datetime, str, int]
+)
 
 
 def gen_consecutive_comparison(
@@ -19,26 +25,38 @@ def gen_consecutive_comparison(
     offset: int = 0,
     limit: int | None = None,
 ):
-    stmt = (
-        select(
-            Scrobble.id,
-            Scrobble.timestamp,
-            kind.column,
-            (
-                kind.column
-                == func.lead(kind.column).over(
-                    order_by=(Scrobble.timestamp, Scrobble.id)
-                )
-            ).label("comparison"),
+    scrobble_id_col = AnalyticsView.scrobble_id
+    ts_col = AnalyticsView.timestamp
+    kind_id_col = kind.id_column.label("kind_id")  # type: ignore[attr-defined]
+    name_col = kind.name_column.label("name")  # type: ignore[attr-defined]
+    subname_col = kind.subname_column.label("subname") if kind.subname_column else None  # type: ignore[attr-defined]
+    comparison_col = (
+        kind_id_col == func.lead(kind_id_col).over(order_by=(ts_col, scrobble_id_col))
+    ).label("comparison")
+
+    if subname_col is not None:
+        stmt = select(
+            scrobble_id_col,
+            ts_col,
+            kind_id_col,
+            name_col,
+            subname_col,
+            comparison_col,
         )
-        .where(Scrobble.user_id == user_id)
-        .offset(offset)
-    )
+    else:
+        stmt = select(
+            scrobble_id_col,
+            ts_col,
+            kind_id_col,
+            name_col,
+            comparison_col,
+        )
+    stmt = stmt.where(AnalyticsView.user_id == user_id).offset(offset)
 
     if from_ts:
-        stmt = stmt.filter(Scrobble.timestamp >= from_ts)
+        stmt = stmt.filter(AnalyticsView.timestamp >= from_ts)
     if to_ts:
-        stmt = stmt.filter(Scrobble.timestamp < to_ts)
+        stmt = stmt.filter(AnalyticsView.timestamp <= to_ts)
 
     if limit:
         stmt = stmt.limit(limit)
@@ -73,16 +91,23 @@ def get_streaks(
     streaks_data: np.ndarray[tuple[Literal[3], int], np.dtype[np.int32]] = np.asarray(
         streak_gen(streak_start, min_length)
     )
-    streaks: list[tuple[datetime.datetime, datetime.datetime, str, int]]
-    streaks = [
-        (
+    streaks: list[StreakType]
+
+    def get_streak_values_from_id(i: int) -> StreakType:
+        values = (
             consecutive_bool[streaks_data[i, 0]]["timestamp"],  # Streak start timestamp
             consecutive_bool[streaks_data[i, 1]]["timestamp"],  # Streak end timestamp
-            consecutive_bool[streaks_data[i, 0]][kind.value],  # Streak value
+            consecutive_bool[streaks_data[i, 0]]["name"],  # Streak name
             streaks_data[i, 2],  # Streak Length
         )
+        if "subname" in consecutive_bool[streaks_data[i, 0]]:
+            return (*values, consecutive_bool[streaks_data[i, 0]]["subname"])
+        return values
+
+    streaks = [
+        get_streak_values_from_id(i)
         for i in range(streaks_data.shape[0])
-        if consecutive_bool[streaks_data[i, 0]][kind.value]
+        if consecutive_bool[streaks_data[i, 0]]["name"]
     ]
 
     return streaks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,11 @@
 from pathlib import Path
-
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, DDL
 from sqlalchemy.orm import sessionmaker
 from testcontainers.postgres import PostgresContainer
 from memoryfm.io.lastfmstats import from_lastfmstats
 from memoryfm.models.core import Base
+
 
 data_dir = Path(__file__).resolve().parent / "data"
 json_dir = data_dir / "json"
@@ -23,7 +23,42 @@ def postgres_container():
 @pytest.fixture(scope="session")
 def engine(postgres_container):
     engine = create_engine(postgres_container.get_connection_url())
+
+    view_name = "analytics_view"
+    view_table = Base.metadata.tables.get(view_name)
+
+    if view_table is not None:
+        Base.metadata._remove_table(view_name, schema=view_table.schema)
+
     Base.metadata.create_all(engine)
+
+    if view_table is not None:
+        Base.metadata.tables._insert_item(view_name, view_table)
+
+    view_ddl = DDL("""
+        CREATE VIEW analytics_view AS
+        SELECT
+            s.id AS scrobble_id,
+            s.timestamp,
+            u.id AS user_id,
+            u.username,
+            t.id AS track_id,
+            t.name AS track,
+            al.id AS album_id,
+            al.name AS album,
+            ar.id AS artist_id,
+            ar.name AS artist
+        FROM scrobbles s
+        JOIN users u ON s.user_id = u.id
+        JOIN tracks t ON s.track_id = t.id
+        JOIN albums al ON t.album_id = al.id
+        JOIN artists ar ON t.artist_id = ar.id
+    """)
+
+    with engine.connect() as conn:
+        conn.execute(view_ddl)
+        conn.commit()
+
     yield engine
 
     engine.dispose()

--- a/tests/io/test_io_lastfmstats.py
+++ b/tests/io/test_io_lastfmstats.py
@@ -8,7 +8,7 @@ from memoryfm.errors import (
     InvalidDataError,
 )
 import memoryfm.services.user_service as userv
-from memoryfm.models.core import Scrobble
+from memoryfm.models.core import AnalyticsView
 
 data_dir = Path(__file__).resolve().parent.parent / "data"
 json_dir = data_dir / "json"
@@ -34,6 +34,6 @@ class TestFromLastfmstats:
         assert context.tz == "Asia/Kolkata"
         user_id = context.user_id
 
-        stmt = select(Scrobble).where(Scrobble.user_id == user_id)
+        stmt = select(AnalyticsView).where(AnalyticsView.user_id == user_id)
         scrobbles = seeded_db.execute(stmt).fetchall()
         assert len(scrobbles) == 11

--- a/tests/services/test_streaks.py
+++ b/tests/services/test_streaks.py
@@ -34,5 +34,20 @@ def test_streaks_by_year(seeded_db: Session):
     )
     assert streaks is not None
     assert len(streaks) == 2
+    assert len(streaks[1]) == 5
     assert streaks[0][2] == "Valentine"
     assert streaks[1][3] == 4
+    assert streaks[1][4] == "Fiona Apple"
+
+
+def test_artist_streaks(seeded_db: Session):
+    streaks = strkserv.get_streaks_by_year(
+        seeded_db,
+        username,
+        ChartKindColumn.Artist,
+        year,
+        min_length,
+    )
+    assert streaks is not None
+    assert len(streaks) > 0
+    assert len(streaks[0]) == 4


### PR DESCRIPTION
## Pull Request Summary

This PR refactors analytics services to fetch data from `AnalyticsView` instead of the scrobbles table. This is part of the refactor to remove data redundancy by removing artist, album, and track names in scrobbles table and instead use relational models and track_id.

## Type of Change

- [x]  Code Refactor
- [x]  Tests

## Changes

### Back-end Services and API

- Add properties for `ChartKindColumn`:
  - `name_column`
  - `subname_column`
  - `id_column`
- Refactor following services to use `AnalyticsView` and id columns to
  group by kind
  - `get_summary_by_user`
  - `get_top_charts_by_user`
  - `get_daily_scrobbles_count`
  - `get_frequency_cte`
  - `get_frequency_proportions_cte`
  - `get_top_charts_by_freq`
  - `get_attachment_moments`
  - `get_streak_values_from_id`
- Add subname to streak when relevant (kind = album or track)
- Add a StreakType type for single streak.
- Update `ListeningStreak` model to include subname and `StreakType`.
- Update test `test_streaks_by_year` to assert subname.
- Add new test for testing artist streaks (no subname).

### Tests

- Create analytics view in engine configuration.
- Replace `Scrobble` with `AnalyticsView` in `TestFromLastfmstats`
  tests.
- Update test `test_streaks_by_year` to assert subname.
- Add new test for testing artist streaks (no subname).


## Checklist

- [x] Code runs without errors
- [x] Tests added/updated and passed.
- [x] Code style and lint checks passed
