### PR TITLE
refactor: add explicit timezone support to analytics services and API endpoints

### DIFF
--- a/apps/api/routers/analytics.py
+++ b/apps/api/routers/analytics.py
@@ -9,7 +9,6 @@ from apps.api.response_models import (
     TopChart,
 )
 from memoryfm.models.service_enums import ChartKindColumn, Frequency
-from memoryfm.services.user_service import get_user_context
 from memoryfm.storage.session import get_db_session
 import memoryfm.services.stats_service as stserv
 import memoryfm.services.attachment_service as attserv
@@ -38,10 +37,19 @@ def top_charts_recent(
             examples=[0, 10, 50],
         ),
     ] = 10,
+    tz: Annotated[
+        str,
+        Query(
+            description="IANA Timezone string",
+        ),
+    ] = "Etc/UTC",
     session=Depends(get_db_session),
 ):
     """Fetch top charts by period."""
-    return stserv.get_top_charts_by_period(session, username, kind, period, limit) or []
+    return (
+        stserv.get_top_charts_by_period(session, username, kind, period, limit, tz)
+        or []
+    )
 
 
 @router.get("/user/{username}/top", response_model=Sequence[TopChart])
@@ -68,10 +76,15 @@ def top_charts(
             examples=[0, 10, 50],
         ),
     ] = 10,
+    tz: Annotated[
+        str,
+        Query(
+            description="IANA Timezone string",
+        ),
+    ] = "Etc/UTC",
     session=Depends(get_db_session),
 ):
     """Fetch top charts for user in the given datetime range."""
-    tz = get_user_context(session, username).tz
     return (
         stserv.get_top_charts_by_username(
             session,
@@ -124,10 +137,15 @@ def attachment_index(
             le=3.0,
         ),
     ] = 1,
+    tz: Annotated[
+        str,
+        Query(
+            description="IANA Timezone string",
+        ),
+    ] = "Etc/UTC",
     session=Depends(get_db_session),
 ):
     """Fetch Attachment Index for user in the given datetime range."""
-    tz = get_user_context(session, username).tz
     return (
         attserv.get_weighted_attachment_index_by_username(
             session,
@@ -137,6 +155,7 @@ def attachment_index(
             normalize_timestamp(to_ts, tz),
             freq,
             alpha,
+            tz,
         )
         or []
     )
@@ -172,6 +191,12 @@ def attachment_index_last(
             le=3.0,
         ),
     ] = 1,
+    tz: Annotated[
+        str,
+        Query(
+            description="IANA Timezone string",
+        ),
+    ] = "Etc/UTC",
     session=Depends(get_db_session),
 ):
     """Fetch Attachment Index for user in the given period."""
@@ -183,6 +208,7 @@ def attachment_index_last(
             period,
             freq,
             alpha,
+            tz,
         )
         or []
     )
@@ -235,10 +261,15 @@ def attachment_moments(
             description="Threshold z_score for choosing top attachment moments.", ge=1
         ),
     ] = 1,
+    tz: Annotated[
+        str,
+        Query(
+            description="IANA Timezone string",
+        ),
+    ] = "Etc/UTC",
     session=Depends(get_db_session),
 ):
     """Fetch Attachment Moments for user in the given datetime range."""
-    tz = get_user_context(session, username).tz
     return (
         attserv.get_attachment_moments(
             session,
@@ -249,6 +280,7 @@ def attachment_moments(
             freq,
             alpha,
             threshold,
+            tz,
         )
         or []
     )
@@ -293,6 +325,12 @@ def attachment_moments_last(
             description="Threshold z_score for choosing top attachment moments.", ge=1
         ),
     ] = 1,
+    tz: Annotated[
+        str,
+        Query(
+            description="IANA Timezone string",
+        ),
+    ] = "Etc/UTC",
     session=Depends(get_db_session),
 ):
     """Fetch Attachment Moments for user in the given period."""
@@ -305,6 +343,7 @@ def attachment_moments_last(
             freq,
             alpha,
             threshold,
+            tz,
         )
         or []
     )
@@ -323,6 +362,12 @@ def streaks(
         int, Query(description="Year for which streaks are to be fetched.", ge=1971)
     ],
     min_length: Annotated[int, Query(description="Minimum length of streaks.", ge=2)],
+    tz: Annotated[
+        str,
+        Query(
+            description="IANA Timezone string",
+        ),
+    ] = "Etc/UTC",
     session=Depends(get_db_session),
 ):
     """Fetch listening streaks for the user in a given year."""
@@ -332,6 +377,7 @@ def streaks(
         kind,
         year,
         min_length,
+        tz,
     )
     if not service_data:
         return []

--- a/apps/api/routers/user.py
+++ b/apps/api/routers/user.py
@@ -65,17 +65,32 @@ def summary(username: TrimmedStr, session=Depends(get_db_session)):
 def recent_scrobbles(
     username: TrimmedStr,
     weeks: Annotated[int, Query(description="Number of weeks to fetch ", ge=1)] = 8,
+    tz: Annotated[
+        str,
+        Query(
+            description="IANA Timezone string",
+        ),
+    ] = "Etc/UTC",
     session=Depends(get_db_session),
 ):
     """Get recent daily scrobble counts for user."""
-    data = stserv.get_daily_scrobbles_count(session, username, limit=weeks * 7)
+    data = stserv.get_daily_scrobbles_count(session, username, limit=weeks * 7, tz=tz)
     return RecentActivity.from_service_data(data)
 
 
 @router.get("/user/{username}/year_range", response_model=YearRange)
-def year_range(username: TrimmedStr, session=Depends(get_db_session)):
+def year_range(
+    username: TrimmedStr,
+    tz: Annotated[
+        str,
+        Query(
+            description="IANA Timezone string",
+        ),
+    ] = "Etc/UTC",
+    session=Depends(get_db_session),
+):
     """Get scrobbling year range for user."""
-    return get_year_range(session, username)
+    return get_year_range(session, username, tz)
 
 
 @router.post("/user/{username}/refresh")

--- a/src/memoryfm/services/attachment_service.py
+++ b/src/memoryfm/services/attachment_service.py
@@ -23,12 +23,13 @@ def get_renyi_entropy_by_username(
     to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
     alpha: float = 1,
+    tz: str = "Etc/UTC",
 ) -> Sequence[RowMapping] | None:
     user = get_user_by_username(session, username)
     if user:
         user_id = user.id
         return attrepo.get_renyi_entropy(
-            session, user_id, kind, from_ts, to_ts, freq, alpha
+            session, user_id, kind, from_ts, to_ts, freq, alpha, tz
         )
     return None
 
@@ -41,12 +42,13 @@ def get_attachment_index_by_username(
     to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
     alpha: float = 1,
+    tz: str = "Etc/UTC",
 ):
     user = get_user_by_username(session, username)
     if user:
         user_id = user.id
         return attrepo.get_attachment_index(
-            session, user_id, kind, from_ts, to_ts, freq, alpha
+            session, user_id, kind, from_ts, to_ts, freq, alpha, tz
         )
     return None
 
@@ -59,12 +61,13 @@ def get_weighted_attachment_index_by_username(
     to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
     alpha: float = 1,
+    tz: str = "Etc/UTC",
 ):
     user = get_user_by_username(session, username)
     if user:
         user_id = user.id
         entropy = attrepo.get_renyi_entropy(
-            session, user_id, kind, from_ts, to_ts, freq, alpha
+            session, user_id, kind, from_ts, to_ts, freq, alpha, tz
         )
         if entropy:
             df = pd.DataFrame(entropy)
@@ -83,13 +86,13 @@ def get_weighted_attachment_by_period(
     period: int | Literal["all_time"],
     freq: Frequency = Frequency.D,
     alpha: float = 1,
+    tz: str = "Etc/UTC",
 ):
     user = get_user_by_username(session, username)
     if user:
-        tz = user.tz
         from_ts = normalize_timestamp(get_datelimit_from_period(period), tz)
         return get_weighted_attachment_index_by_username(
-            session, username, kind, from_ts, to_ts=None, freq=freq, alpha=alpha
+            session, username, kind, from_ts, to_ts=None, freq=freq, alpha=alpha, tz=tz
         )
     return None
 
@@ -103,6 +106,7 @@ def get_attachment_moments(
     freq: Frequency = Frequency.D,
     alpha: float = 1,
     threshold: float = 1,
+    tz: str = "Etc/UTC",
 ):
     user = get_user_by_username(session, username)
     if user:
@@ -115,9 +119,10 @@ def get_attachment_moments(
             to_ts,
             freq,
             alpha,
+            tz,
         )
         top_charts = get_top_charts_by_freq(
-            session, user_id, kind, from_ts, to_ts, freq
+            session, user_id, kind, from_ts, to_ts, freq, tz
         )
         if weighted_att and top_charts:
             df = pd.DataFrame(weighted_att)
@@ -154,10 +159,10 @@ def get_attachment_moments_by_period(
     freq: Frequency = Frequency.D,
     alpha: float = 1,
     threshold: float = 1,
+    tz: str = "Etc/UTC",
 ):
     user = get_user_by_username(session, username)
     if user:
-        tz = user.tz
         from_ts = normalize_timestamp(get_datelimit_from_period(period), tz)
         return get_attachment_moments(
             session,
@@ -168,5 +173,6 @@ def get_attachment_moments_by_period(
             freq=freq,
             alpha=alpha,
             threshold=threshold,
+            tz=tz,
         )
     return None

--- a/src/memoryfm/services/scrobble_service.py
+++ b/src/memoryfm/services/scrobble_service.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from sqlalchemy.exc import SQLAlchemyError
 import memoryfm.storage.scrobble_repo as screpo
 from memoryfm.storage.user_repo import get_user_by_username
+from memoryfm.util.datetime_util import normalize_timestamp
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -37,7 +38,7 @@ def get_end_timestamps(
     return screpo.get_end_timestamps_by_user(session, user_id)
 
 
-def get_year_range(session: Session, username: str):
+def get_year_range(session: Session, username: str, tz: str = "Etc/UTC"):
     user = get_user_by_username(session, username)
     start, end = None, None
     if user:
@@ -45,10 +46,14 @@ def get_year_range(session: Session, username: str):
         timestamps = get_end_timestamps(session, user_id)
         if timestamps:
             start_ts, end_ts = timestamps
-            if start_ts:
-                start = start_ts.year
-            if end_ts:
-                end = end_ts.year
+            start_ts_norm, end_ts_norm = (
+                normalize_timestamp(start_ts, tz),
+                normalize_timestamp(end_ts, tz),
+            )
+            if start_ts_norm:
+                start = start_ts_norm.year
+            if end_ts_norm:
+                end = end_ts_norm.year
     return {"start": start, "end": end}
 
 

--- a/src/memoryfm/services/stats_service.py
+++ b/src/memoryfm/services/stats_service.py
@@ -43,10 +43,10 @@ def get_top_charts_by_period(
     kind: ChartKindColumn,
     period: int | Literal["all_time"],
     limit: int | None = 10,
+    tz: str = "Etc/UTC",
 ) -> Sequence[RowMapping] | None:
     user = get_user_by_username(session, username)
     if user:
-        tz = user.tz
         from_ts = normalize_timestamp(get_datelimit_from_period(period), tz)
         return get_top_charts_by_username(session, username, kind, from_ts, limit=limit)
     return None
@@ -57,9 +57,10 @@ def get_daily_scrobbles_count(
     username: str,
     till: datetime.date | None = None,
     limit: int = 56,
+    tz: str = "Etc/UTC",
 ) -> tuple[datetime.date, datetime.date, Sequence[RowMapping]] | None:
     user = get_user_by_username(session, username)
     if user:
         user_id = user.id
-        return strepo.get_daily_scrobbles_count(session, user_id, till, limit)
+        return strepo.get_daily_scrobbles_count(session, user_id, till, limit, tz)
     return None

--- a/src/memoryfm/services/streaks_service.py
+++ b/src/memoryfm/services/streaks_service.py
@@ -1,4 +1,5 @@
 import datetime
+from zoneinfo import ZoneInfo
 
 from sqlalchemy.orm import Session
 
@@ -35,9 +36,10 @@ def get_streaks_by_year(
     kind: ChartKindColumn,
     year: int,
     min_length: int = 2,
+    tz: str = "Etc/UTC",
 ):
-    from_ts = datetime.datetime(year=year, month=1, day=1)
-    to_ts = datetime.datetime(year=year, month=12, day=31)
+    from_ts = datetime.datetime(year=year, month=1, day=1, tzinfo=ZoneInfo(tz))
+    to_ts = datetime.datetime(year=year, month=12, day=31, tzinfo=ZoneInfo(tz))
     return get_streaks_by_username(
         session,
         username,

--- a/src/memoryfm/storage/attachment_index.py
+++ b/src/memoryfm/storage/attachment_index.py
@@ -22,8 +22,11 @@ def get_renyi_entropy(
     to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
     alpha: float = 1,
+    tz: str = "Etc/UTC",
 ) -> Sequence[RowMapping] | None:
-    stmt_cte_props = get_frequency_proportions_cte(user_id, kind, from_ts, to_ts, freq)
+    stmt_cte_props = get_frequency_proportions_cte(
+        user_id, kind, from_ts, to_ts, freq, tz
+    )
     cte_props_cols = stmt_cte_props.columns
     prop_col = cte_props_cols["prop"]
     total_scrobbles_col = func.any_value(cte_props_cols["total_scrobbles"])
@@ -51,8 +54,9 @@ def get_attachment_index(
     to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
     alpha: float = 1,
+    tz: str = "Etc/UTC",
 ):
-    entropy = get_renyi_entropy(session, user_id, kind, from_ts, to_ts, freq, alpha)
+    entropy = get_renyi_entropy(session, user_id, kind, from_ts, to_ts, freq, alpha, tz)
     att_index = (
         [{"day": k["day"], "value": 100 * exp(-k["value"])} for k in entropy]
         if entropy

--- a/src/memoryfm/storage/cte_util.py
+++ b/src/memoryfm/storage/cte_util.py
@@ -12,11 +12,15 @@ def get_frequency_cte(
     from_ts: datetime.datetime | None = None,
     to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
+    tz: str = "Etc/UTC",
 ) -> CTE:
     id_col = kind.id_column.label("id")  # type: ignore[attr-defined]
     name_col = kind.name_column.label("name")  # type: ignore[attr-defined]
     subname_col = kind.subname_column.label("subname") if kind.subname_column else None  # type: ignore[attr-defined]
-    date_col = func.date_trunc(freq.value, AnalyticsView.timestamp).label(freq.value)
+
+    local_ts = AnalyticsView.timestamp.op("AT TIME ZONE")(tz)
+    truncated_local = func.date_trunc(freq.value, local_ts)
+    date_col = truncated_local.label(freq.value)
 
     if subname_col is not None:
         stmt = select(date_col, id_col, name_col, subname_col)
@@ -59,8 +63,9 @@ def get_frequency_proportions_cte(
     from_ts: datetime.datetime | None = None,
     to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
+    tz: str = "Etc/UTC",
 ) -> CTE:
-    stmt_cte_freq = get_frequency_cte(user_id, kind, from_ts, to_ts, freq)
+    stmt_cte_freq = get_frequency_cte(user_id, kind, from_ts, to_ts, freq, tz)
     cte_freq_cols = stmt_cte_freq.columns
     scrobbles_col = cte_freq_cols["scrobbles"]
     total_scrobbles_col = func.sum(scrobbles_col).over(

--- a/src/memoryfm/storage/stats_repo.py
+++ b/src/memoryfm/storage/stats_repo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 import datetime
+from zoneinfo import ZoneInfo
 from sqlalchemy import desc, distinct, select, func
 from memoryfm.models.core import AnalyticsView
 from memoryfm.models.service_enums import Frequency
@@ -94,20 +95,21 @@ def get_daily_scrobbles_count(
     user_id: int,
     till: datetime.date | None = None,
     limit: int = 56,
+    tz: str = "Etc/UTC",
 ) -> tuple[datetime.date, datetime.date, Sequence[RowMapping]]:
-    datelimit = till if till else datetime.date.today()
+    datelimit = till if till else datetime.datetime.now(ZoneInfo(tz)).date()
     to_date = datelimit
     from_date = to_date - datetime.timedelta(days=limit)
 
-    date_col = func.date(AnalyticsView.timestamp)
+    date_col = func.date(AnalyticsView.timestamp.op("AT TIME ZONE")(tz))
     columns = [
         date_col.label("Date"),
         func.count(AnalyticsView.scrobble_id).label("Scrobbles"),
     ]
     conditions = [
         AnalyticsView.user_id == user_id,
-        func.date(AnalyticsView.timestamp) <= to_date,
-        func.date(AnalyticsView.timestamp) >= from_date,
+        date_col <= to_date,
+        date_col >= from_date,
     ]
     orderby = (desc(date_col),)
     groupby = (date_col,)
@@ -124,8 +126,9 @@ def get_top_charts_by_freq(
     from_ts: datetime.datetime | None = None,
     to_ts: datetime.datetime | None = None,
     freq: Frequency = Frequency.D,
+    tz: str = "Etc/UTC",
 ) -> Sequence[RowMapping]:
-    stmt_cte_freq = get_frequency_cte(user_id, kind, from_ts, to_ts, freq)
+    stmt_cte_freq = get_frequency_cte(user_id, kind, from_ts, to_ts, freq, tz)
     cols = stmt_cte_freq.columns
     freq_col = cols[freq.value]
     scrobbles_col = cols["scrobbles"]

--- a/src/memoryfm/util/datetime_util.py
+++ b/src/memoryfm/util/datetime_util.py
@@ -36,9 +36,11 @@ def validate_tz(tz: str | None = None) -> str:
 
 def get_datelimit_from_period(period: int | Literal["all_time"] = 7):
     if period != "all_time":
-        return datetime.datetime.now() - datetime.timedelta(days=period)
+        return datetime.datetime.now(tz=ZoneInfo("Etc/UTC")) - datetime.timedelta(
+            days=period
+        )
     else:
-        return datetime.datetime.fromtimestamp(0)
+        return datetime.datetime.fromtimestamp(0, tz=ZoneInfo("Etc/UTC"))
 
 
 def normalize_timestamp(


### PR DESCRIPTION
## Pull Request Summary

This PR adds explicit timezone support across analytics API endpoints, services, and storage queries.

Previously, several analytics calculations either:
- implicitly depended on the user's stored timezone, or
- grouped timestamps using UTC database timestamps.

This caused boundary issues for:
- daily aggregations
- streak calculations
- yearly ranges
- period-based analytics

## Type of Change

- [x]  New Feature
- [x]  Code Refactor


## Changes

### Datetime utilities

- Normalize period calculations to use timezone-aware UTC datetimes.

### Storage/Query layer

Analytics aggregations now use timezone-aware grouping via PostgreSQL `AT TIME ZONE`.

This affects:
- date truncation
- frequency grouping
- daily scrobble counts
- attachment calculations

### Service layer

- Propagate timezone explicitly through analytics services.
- Remove implicit timezone lookups from router/service boundaries.
- Year-based calculations and streak boundaries now respect the requested timezone.

### Back-end API

Add optional `tz` query parameters (default: `Etc/UTC`) to analytics endpoints including:
- top charts
- attachment index
- attachment moments
- streaks
- recent scrobbles
- year range

## Checklist

- [x] Code runs without errors
- [x] Code style and lint checks passed
