### PR TITLE
web: standardize query params and add timezone support to front-end API

### DIFF
--- a/apps/web/src/api/analytics.ts
+++ b/apps/web/src/api/analytics.ts
@@ -1,12 +1,14 @@
 import { handleResponse } from "@/api/user";
+import { getClientTimezone } from "@/api/tzhelper";
 import type { KindType } from "@/typing";
 import { BACKEND_URL } from "@/api/urls";
 
 const alpha = 2;
 const threshold = 1.5;
 const min_length = 5;
+const freq = "day";
 
-export const fetchAttachmentMoments = async(
+export const fetchAttachmentMoments = async (
     { username, kind, from_ts, to_ts }: {
         username: string;
         kind: KindType;
@@ -15,8 +17,25 @@ export const fetchAttachmentMoments = async(
 
     }
 ) => {
+    const tz = getClientTimezone();
+
+    const params = new URLSearchParams({
+        kind,
+        freq,
+        alpha: String(alpha),
+        threshold: String(threshold),
+        tz
+    });
+
+    if (from_ts) {
+        params.append("from_ts", from_ts);
+    }
+
+    if (to_ts) {
+        params.append("to_ts", to_ts);
+    }
     const res = await fetch(
-        `${BACKEND_URL}/user/${username}/attachment_moments?kind=${kind}&from_ts=${from_ts}&to_ts=${to_ts}&freq=day&alpha=${alpha}&threshold=${threshold}`
+        `${BACKEND_URL}/user/${username}/attachment_moments?${params.toString()}`
     );
     return handleResponse(res);
 };
@@ -24,13 +43,25 @@ export const fetchAttachmentMoments = async(
 export const fetchAttachmentMomentsByPeriod = async (
     username: string, kind: string, period: number | "all_time"
 ) => {
+    const tz = getClientTimezone();
+
+    const params = new URLSearchParams({
+        kind,
+        period: String(period),
+        freq,
+        alpha: String(alpha),
+        threshold: String(threshold),
+        tz
+    });
+
+
     const res = await fetch(
-        `${BACKEND_URL}/user/${username}/attachment_moments_last?kind=${kind}&period=${period}&freq=day&alpha=${alpha}&threshold=${threshold}`
+        `${BACKEND_URL}/user/${username}/attachment_moments_last?${params.toString()}`
     );
     return handleResponse(res);
 }
 
-export const fetchAttachmentIndex = async(
+export const fetchAttachmentIndex = async (
     { username, kind, from_ts, to_ts }: {
         username: string;
         kind: KindType;
@@ -39,8 +70,25 @@ export const fetchAttachmentIndex = async(
 
     }
 ) => {
+    const tz = getClientTimezone();
+
+    const params = new URLSearchParams({
+        kind,
+        freq,
+        alpha: String(alpha),
+        tz
+    });
+
+    if (from_ts) {
+        params.append("from_ts", from_ts);
+    }
+
+    if (to_ts) {
+        params.append("to_ts", to_ts);
+    }
+
     const res = await fetch(
-        `${BACKEND_URL}/user/${username}/attachment?kind=${kind}&from_ts=${from_ts}&to_ts=${to_ts}&freq=day&alpha=${alpha}`
+        `${BACKEND_URL}/user/${username}/attachment?${params.toString()}`
     );
     return handleResponse(res);
 }
@@ -48,8 +96,18 @@ export const fetchAttachmentIndex = async(
 export const fetchAttachmentIndexByPeriod = async (
     username: string, kind: string, period: number | "all_time"
 ) => {
+    const tz = getClientTimezone();
+
+    const params = new URLSearchParams({
+        kind,
+        period: String(period),
+        freq,
+        alpha: String(alpha),
+        tz
+    });
+
     const res = await fetch(
-        `${BACKEND_URL}/user/${username}/attachment_last?kind=${kind}&period=${period}&freq=day&alpha=${alpha}`
+        `${BACKEND_URL}/user/${username}/attachment_last?${params.toString()}`
     );
     return handleResponse(res);
 }
@@ -57,8 +115,17 @@ export const fetchAttachmentIndexByPeriod = async (
 export const fetchStreaksByYear = async (
     username: string, kind: KindType, year: number
 ) => {
+    const tz = getClientTimezone();
+
+    const params = new URLSearchParams({
+        kind,
+        year: String(year),
+        min_length: String(min_length),
+        tz
+    });
+
     const res = await fetch(
-        `${BACKEND_URL}/user/${username}/streaks_yearly?kind=${kind}&year=${year}&min_length=${min_length}`
+        `${BACKEND_URL}/user/${username}/streaks_yearly?${params.toString()}`
     );
     return handleResponse(res);
 }

--- a/apps/web/src/api/topcharts.ts
+++ b/apps/web/src/api/topcharts.ts
@@ -1,13 +1,30 @@
 import { BACKEND_URL } from "@/api/urls";
 import { handleResponse } from "@/api/user";
+import { getClientTimezone } from "@/api/tzhelper";
 import type { ChartsInput } from "@/typing";
 
 
 export const fetchTopCharts = async (
     { username, kind, from_ts, to_ts, limit }: ChartsInput
 ) => {
+    const tz = getClientTimezone();
+
+    const params = new URLSearchParams({
+        kind,
+        tz,
+        limit: String(limit)
+    })
+
+    if (from_ts) {
+        params.append("from_ts", from_ts);
+    }
+
+    if (to_ts) {
+        params.append("to_ts", to_ts);
+    }
+
     const res = await fetch(
-        `${BACKEND_URL}/user/${username}/top?kind=${kind}&from_ts=${from_ts}&to_ts=${to_ts}&limit=${limit}`
+        `${BACKEND_URL}/user/${username}/top?${params.toString()}`
     );
     return handleResponse(res);
 };

--- a/apps/web/src/api/tzhelper.ts
+++ b/apps/web/src/api/tzhelper.ts
@@ -1,0 +1,2 @@
+export const getClientTimezone = () =>
+  Intl.DateTimeFormat().resolvedOptions().timeZone || "Etc/UTC";

--- a/apps/web/src/api/user.ts
+++ b/apps/web/src/api/user.ts
@@ -1,5 +1,5 @@
 import { BACKEND_URL } from "@/api/urls";
-
+import { getClientTimezone } from "@/api/tzhelper";
 
 export const handleResponse = async (res: Response) => {
   const data = await res.json();
@@ -50,22 +50,47 @@ export const fetchUserSummary = async (username: string) => {
 };
 
 export const fetchRecentActivity = async (username: string, weeks: number) => {
-  const res = await fetch(`${BACKEND_URL}/user/${username}/recent_scrobbles?weeks=${weeks}`);
+  const tz = getClientTimezone();
+
+  const params = new URLSearchParams({
+    weeks: String(weeks),
+    tz
+  });
+
+  const res = await fetch(`${BACKEND_URL}/user/${username}/recent_scrobbles?${params.toString()}`);
   return handleResponse(res);
 };
 
 export const fetchTopChartsByPeriod = async (
-  username: string, kind: string, period: number | "all_time", limit: number
+  username: string,
+  kind: string,
+  period: number | "all_time",
+  limit: number
 ) => {
+
+  const tz = getClientTimezone();
+
+  const params = new URLSearchParams({
+    kind,
+    period: String(period),
+    limit: String(limit),
+    tz
+  });
+
   const res = await fetch(
-    `${BACKEND_URL}/user/${username}/top_last?kind=${kind}&period=${period}&limit=${limit}`
+    `${BACKEND_URL}/user/${username}/top_last?${params.toString()}`
   );
   return handleResponse(res);
 };
 
 export const fetchYearRange = async (username: string) => {
+  const tz = getClientTimezone();
+
+  const params = new URLSearchParams({
+    tz
+  })
   const res = await fetch(
-    `${BACKEND_URL}/user/${username}/year_range`
+    `${BACKEND_URL}/user/${username}/year_range?${params.toString()}`
   );
   return handleResponse(res);
 };


### PR DESCRIPTION
## Pull Request Summary

This PR standardizes how query parameters are constructed across all analytics-related API functions in the front-end.

In addition, it also introduces explicit client-side timezone support.

## Type of Change

- [x]  Code Refactor

## Changes

- Replace manual query string construction with URLSearchParams across analytics API functions.
  This ensures:
  - consistent URL encoding for all query parameters
  - correct handling of optional parameters (`from_ts`, `to_ts`)
  - safe encoding of timezone strings (e.g. Asia/Kolkata)
  - elimination of null/undefined leaking into URLs
- Explicitly inject timezone in params at the API layer using a shared helper.