### PR TITLE
db: remove redundant fields artist, album, track from `Scrobble`

### DIFF
--- a/apps/alembic/migrations/versions/6e78d39b140d_drop_artists_albums_tracks_columns_from_.py
+++ b/apps/alembic/migrations/versions/6e78d39b140d_drop_artists_albums_tracks_columns_from_.py
@@ -1,0 +1,33 @@
+"""drop artists, albums, tracks columns from scrobbles table
+
+Revision ID: 6e78d39b140d
+Revises: bf0507c235e9
+Create Date: 2026-05-08 13:46:33.383371
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "6e78d39b140d"
+down_revision: Union[str, Sequence[str], None] = "bf0507c235e9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_column("scrobbles", "track")
+    op.drop_column("scrobbles", "album")
+    op.drop_column("scrobbles", "artist")
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.add_column("scrobbles", sa.Column("album", sa.VARCHAR(), nullable=True))
+    op.add_column("scrobbles", sa.Column("track", sa.VARCHAR(), nullable=True))
+    op.add_column("scrobbles", sa.Column("artist", sa.VARCHAR(), nullable=True))

--- a/src/memoryfm/models/core.py
+++ b/src/memoryfm/models/core.py
@@ -134,17 +134,6 @@ class Scrobble(Base):
         doc="Timestamp at which the track was scrobbled. "
         "Stored as UTC with timezone awareness.",
     )
-    track: Mapped[str] = mapped_column(
-        String(), doc="Name/title of the scrobbled track."
-    )
-    artist: Mapped[str] = mapped_column(
-        String(), doc="Artist name for the scrobbled track."
-    )
-    album: Mapped[str] = mapped_column(
-        String(),
-        server_default="",
-        doc="(Optional) Album name for the scrobbled track.",
-    )
 
     track_id: Mapped[int] = mapped_column(ForeignKey("tracks.id"), index=True)
 

--- a/src/memoryfm/storage/scrobble_repo.py
+++ b/src/memoryfm/storage/scrobble_repo.py
@@ -100,7 +100,7 @@ def insert_scrobbles_by_user(session: Session, user_id: int, scrobbles: Sequence
                     artists_map[(s["artist"])],
                 )
             ],
-            **s,
+            "timestamp": s["timestamp"],
         }
         for s in scrobbles
     ]


### PR DESCRIPTION
## Pull Request Summary

This PR completed the refactor to remove redundanct fields artist, album, and track from the scrobbles table.
 
## Type of Change

- [x]  Code Refactor

## Changes

- Remove redundant fields artist, album, and tracks from `Scrobble` model.
- Add alembic migration revision for the same.
- Update insert service `insert_scrobbles_by_user` to insert only the currently existing columns (`user_id`, `track_id`, `timestamp`).

## Checklist

- [x] Code runs without errors
- [x] Tests added/updated and passed.
- [x] Code style and lint checks passed
