### PR TITLE
enh: drop redundant index,  improve sync ui and add external links to repo, feedback, and support

### DIFF
--- a/apps/alembic/migrations/versions/386c7179cc0c_drop_scrobbles_timestamp_index_in_.py
+++ b/apps/alembic/migrations/versions/386c7179cc0c_drop_scrobbles_timestamp_index_in_.py
@@ -1,0 +1,33 @@
+"""drop scrobbles timestamp index in favour of composite index
+
+Revision ID: 386c7179cc0c
+Revises: 6e78d39b140d
+Create Date: 2026-05-18 06:17:41.594499
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "386c7179cc0c"
+down_revision: Union[str, Sequence[str], None] = "6e78d39b140d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_index("ix_scrobbles_timestamp", table_name="scrobbles", if_exists=True)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.create_index(
+        "ix_scrobbles_timestamp",
+        table_name="scrobbles",
+        columns=["timestamp"],
+        if_not_exists=True,
+    )

--- a/apps/web/src/components/features/overview/sync_progress.tsx
+++ b/apps/web/src/components/features/overview/sync_progress.tsx
@@ -47,12 +47,13 @@ export default function SyncProgress(
             direction={"column"}
             padding={5}
             mb={"6"}
+            gap={"6"}
             align="center"
             alignItems={"center"}
         >
             <Progress.Root
                 value={progressPercent}
-                width="sm"
+                width="xl"
             >
                 <HStack gap={"5"}>
                     <Progress.Label>Syncing scrobbles...</Progress.Label>
@@ -60,10 +61,19 @@ export default function SyncProgress(
                         <Progress.Range />
                     </Progress.Track>
                     <Progress.ValueText>
-                        {progressPercent.toPrecision(3)}%
+                        {progressPercent.toPrecision(3)}% ({syncStatus.fetched_scrobbles}/{syncStatus.total_scrobbles})
                     </Progress.ValueText>
                 </HStack>
             </Progress.Root>
+            <Alert.Root status={"info"} width={"md"} justifySelf={"center"}>
+                <Alert.Indicator />
+                <Alert.Content>
+                    <Alert.Title>First sync may take some time for large listening histories.</Alert.Title>
+                    <Alert.Description> While your scrobbles
+                        sync, you can still view your stats and charts using the sidebar.
+                        .</Alert.Description>
+                </Alert.Content>
+            </Alert.Root>
         </Flex>
     )
 }

--- a/apps/web/src/components/layout/layout.tsx
+++ b/apps/web/src/components/layout/layout.tsx
@@ -1,7 +1,7 @@
 import { Outlet, useParams } from "react-router-dom";
 
 // Hooks
-import { useNavItems } from "@/components/layout/nav_sidebar/nav_sidebar.config";
+import { useNavItems, useExternalLinks } from "@/components/layout/nav_sidebar/nav_sidebar.config";
 
 // Components
 // Chakra UI
@@ -16,39 +16,40 @@ export default function AppLayout() {
 
   if (!username?.trim()) {
     return null;
-    }
+  }
 
   const navItems = useNavItems(username);
+  const externalLinks = useExternalLinks();
 
   const { open } = useSidebarNav();
   const sidebarWidth = open ? "260px" : "72px";
 
   return (
-      <Flex minH={"100vh"} direction={"column"}>
+    <Flex minH={"100vh"} direction={"column"}>
 
-        {/* Headerbar */}
-        <HeaderBar username={username!} />
-        
-        {/* Sidebar */}
-        <Flex flex="1" overflow={"hidden"}>
-          <Box
-            w={sidebarWidth}
-            bg="bg.muted"
-            boxShadow={"md"}
-          >
-            <SidebarNav navItems={navItems}/>
-          </Box>
-          
-        <Box 
-            as="main" 
-            flex="1" 
-            ml={0} 
-            p="6" 
-            transition="margin-left 0.2s"
-          >
-            <Outlet />
-          </Box>
-          </Flex>
-        </Flex>
+      {/* Headerbar */}
+      <HeaderBar username={username!} />
+
+      {/* Sidebar */}
+      <Flex flex="1" overflow={"hidden"}>
+        <Box
+          w={sidebarWidth}
+          bg="bg.muted"
+          boxShadow={"md"}
+        >
+          <SidebarNav navItems={navItems} externalLinks={externalLinks} />
+        </Box>
+
+        <Box
+          as="main"
+          flex="1"
+          ml={0}
+          p="6"
+          transition="margin-left 0.2s"
+        >
+          <Outlet />
+        </Box>
+      </Flex>
+    </Flex>
   );
 }

--- a/apps/web/src/components/layout/nav_sidebar/nav_items.tsx
+++ b/apps/web/src/components/layout/nav_sidebar/nav_items.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, List, Text as ChakraText } from "@chakra-ui/react";
+import { Box, Flex, List, Text as ChakraText, Link, VStack, Separator, } from "@chakra-ui/react";
 import type { IconType } from "react-icons";
 import { NavLink } from "react-router-dom";
 import { useSidebarNav } from "./nav_sidebar_context";
@@ -8,6 +8,12 @@ export interface SidebarNavItem {
   icon: IconType;
   label: string;
   pathname: string;
+}
+
+export interface ExternalLinkItem {
+  icon: IconType;
+  label: string;
+  href: string;
 }
 
 export interface SidebarNavItemsProps {
@@ -50,19 +56,57 @@ function sidebarItem(
 }
 
 
+function ExternalItem(item: ExternalLinkItem, index: number) {
+
+  const { open } = useSidebarNav();
+
+  return (
+    <List.Item key={index} listStyle={"none"}>
+      <Link
+        href={item.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ textDecoration: 'none', width: '100%' }}
+      >
+        <Box
+          display="block"
+          w="full"
+          borderRadius="md"
+          transition="all 0.2s"
+          _hover={{ bg: "bg.subtle" }}
+        >
+          <Flex align="center" gap="4" px="3" py="2">
+            <Box fontSize="20px"><item.icon /></Box>
+            {open && (
+              <ChakraText fontWeight="medium">{item.label}</ChakraText>
+            )}
+          </Flex>
+        </Box>
+      </Link>
+    </List.Item>
+  )
+}
+
 export default function SidebarNavItems(
-  { navItems }: SidebarNavItemsProps
+  { navItems, externalLinks }: {
+    navItems: SidebarNavItem[],
+    externalLinks: ExternalLinkItem[]
+  }
 ) {
 
   return (
-    <List.Root
-      gap="2"
-      variant={"plain"}
-      width="full"
-    >
-      {navItems.map(
-        (item, index) => sidebarItem(item, index)
-      )}
-    </List.Root>
-  )
+    <VStack gap="6" h={"full"}>
+      <List.Root gap="2" variant="plain" width="full">
+        {navItems.map((item, index) =>
+          sidebarItem(item, index)
+        )}
+      </List.Root>
+      <Separator/>
+      <List.Root gap="2" variant="plain" width="full">
+        {externalLinks.map((item, index) =>
+          ExternalItem(item, index)
+        )}
+      </List.Root>
+    </VStack>
+  );
 }

--- a/apps/web/src/components/layout/nav_sidebar/nav_sidebar.config.ts
+++ b/apps/web/src/components/layout/nav_sidebar/nav_sidebar.config.ts
@@ -1,10 +1,17 @@
-import { MdBarChart,  MdBolt,  MdFavorite,  MdHome, MdListAlt } from "react-icons/md";
-import type { SidebarNavItem } from "./nav_items";
+import { MdBarChart, MdBolt, MdFavorite, MdHome, MdListAlt, MdOutlineFeedback, MdOutlineVolunteerActivism } from "react-icons/md";
+import type { ExternalLinkItem, SidebarNavItem } from "./nav_items";
+import { FaGithub } from "react-icons/fa";
 
 export const useNavItems = (username: string): SidebarNavItem[] => [
-    { icon: MdHome, label: "Home", pathname: "/"},
+    { icon: MdHome, label: "Home", pathname: "/" },
     { icon: MdListAlt, label: "Overview", pathname: `/user/${username}/overview` },
-    { icon: MdBarChart, label: "Top Charts", pathname: `/user/${username}/topcharts`},
-    { icon: MdFavorite, label: "Attachment", pathname: `/user/${username}/attachment`},
-    { icon: MdBolt, label: "Streaks", pathname: `/user/${username}/streaks`},
+    { icon: MdBarChart, label: "Top Charts", pathname: `/user/${username}/topcharts` },
+    { icon: MdFavorite, label: "Attachment", pathname: `/user/${username}/attachment` },
+    { icon: MdBolt, label: "Streaks", pathname: `/user/${username}/streaks` },
+];
+
+export const useExternalLinks = (): ExternalLinkItem[] => [
+    { icon: MdOutlineFeedback, label: "Feedback", href: "https://tally.so/r/Y5JVpz" },
+    { icon: FaGithub, label: "GitHub", href: "https://github.com/shsiddhant/memory.fm/" },
+    { icon: MdOutlineVolunteerActivism, label: "Support Development", href: "https://ko-fi.com/shsiddhant" },
 ];

--- a/apps/web/src/components/layout/nav_sidebar/nav_sidebar.tsx
+++ b/apps/web/src/components/layout/nav_sidebar/nav_sidebar.tsx
@@ -1,25 +1,28 @@
-import { Box, Stack} from "@chakra-ui/react";
+import { Box, Stack } from "@chakra-ui/react";
 import SidebarNavItems from "./nav_items";
-import type { SidebarNavItemsProps } from "./nav_items";
+import type { ExternalLinkItem, SidebarNavItem } from "./nav_items";
 
 
 export default function SidebarNav(
-    { navItems }: SidebarNavItemsProps
+  { navItems, externalLinks }: {
+    navItems: SidebarNavItem[],
+    externalLinks: ExternalLinkItem[]
+  }
 ) {
-    return (
-        <Box
-          as="nav"
-          w="full"
-          h="full"
-          bg="bg.muted"
-          borderRightWidth="1px"
-          borderColor="border.subtle"
-          transition="all 0.2s ease"
-          overflowX="hidden"
-        >
-          <Stack p={"4"} gap={"4"}>
-            <SidebarNavItems navItems={navItems} />
-          </Stack>
-        </Box>
-    )
+  return (
+    <Box
+      as="nav"
+      w="full"
+      h="full"
+      bg="bg.muted"
+      borderRightWidth="1px"
+      borderColor="border.subtle"
+      transition="all 0.2s ease"
+      overflowX="hidden"
+    >
+      <Stack p={"4"} gap={"4"}>
+        <SidebarNavItems navItems={navItems} externalLinks={externalLinks} />
+      </Stack>
+    </Box>
+  )
 }

--- a/src/memoryfm/models/core.py
+++ b/src/memoryfm/models/core.py
@@ -130,7 +130,7 @@ class Scrobble(Base):
     )
     timestamp: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True),
-        index=True,
+        index=False,
         doc="Timestamp at which the track was scrobbled. "
         "Stored as UTC with timezone awareness.",
     )


### PR DESCRIPTION
## Pull Request Summary

This PR drops redundant index on `timestamp` in the `scrobbles` table. It also improves UI/UX by adding clearer info to sync ui.
Additionally, it adds links to repo, feedback form, and support page.

## Type of Change

- [x]  New Feature
- [x]  Code Refactor

## Changes

### Database

- Drop scrobbles `timestamp` index in favour of the composite index. Since queries always filter by users, the composite index on `[timestamp, track_id, user_id]` in table 'scrobbles` is sufficient.

### Web UI/UX

- Improve sync UI
   - Show fetched and total scrobbles near progress percentage during sync.
   - Increase width of progress bar to 'xl'.
   - Show info message to clarify usability while sync is in progress:
   >First sync may take some time for large listening histories.
While your scrobbles sync, you can still view your stats and charts using the sidebar."
- External Links
   - Add a component for external links.
   - Add links to GitHub repository, feedback form, and ko-fi page in the navigation sidebar.

## Checklist

- [x] Code runs without errors
- [x] Tests added/updated and passed.
- [x] Code style and lint checks passed
