### PR TITLE
web: make ui mobile usable, keep sidebar and headerbar sticky.

### DIFF
--- a/apps/web/src/components/features/analytics/limitselector.tsx
+++ b/apps/web/src/components/features/analytics/limitselector.tsx
@@ -14,31 +14,31 @@ export default function LimitSelector(
     const [showTooltip, setShowTooltip] = useState(false)
 
     return (
-        <Slider.Root
-            defaultValue={[10]}
-            value={[value]}
-            min={min}
-            max={100}
-            minW={"300px"}
-            variant={"solid"}
-            colorPalette={"brand"}
-            onValueChange={(details) => onLimitChange(details.value[0])}
-            onPointerEnter={() => setShowTooltip(true)}
-            onPointerLeave={() => setShowTooltip(false)}
-        >
-            <Slider.Control>
-                <Slider.Track colorPalette={"brand"}>
-                    <Slider.Range />
-                </Slider.Track>
-                <Tooltip
-                    open={showTooltip}
-                    content={<Slider.ValueText />}
-                    showArrow
-                    contentProps={{ css: { "--tooltip-bg": "var(--chakra-colors-accent)" } }}
-                >
-          <Slider.Thumb index={0} />
-        </Tooltip>
-            </Slider.Control>
-        </Slider.Root>
+            <Slider.Root
+                defaultValue={[10]}
+                value={[value]}
+                min={min}
+                max={100}
+                minW={{base: "200px", md: "300px"}}
+                variant={"solid"}
+                colorPalette={"brand"}
+                onValueChange={(details) => onLimitChange(details.value[0])}
+                onPointerEnter={() => setShowTooltip(true)}
+                onPointerLeave={() => setShowTooltip(false)}
+            >
+                <Slider.Control>
+                    <Slider.Track colorPalette={"brand"}>
+                        <Slider.Range />
+                    </Slider.Track>
+                    <Tooltip
+                        open={showTooltip}
+                        content={<Slider.ValueText />}
+                        showArrow
+                        contentProps={{ css: { "--tooltip-bg": "var(--chakra-colors-accent)" } }}
+                    >
+                        <Slider.Thumb index={0} />
+                    </Tooltip>
+                </Slider.Control>
+            </Slider.Root>
     )
 }

--- a/apps/web/src/components/features/analytics/periodselector.tsx
+++ b/apps/web/src/components/features/analytics/periodselector.tsx
@@ -3,7 +3,6 @@
 import type { Dates, Mode, ModeOption } from "@/typing";
 import {
   DatePicker,
-  HStack,
   Portal,
   RadioGroup,
   Stack,
@@ -83,10 +82,9 @@ export default function PeriodSelector(
       <RadioGroup.Root
         value={mode as string}
         onValueChange={(details) => onModeChange(details.value as Mode)}
-        mb={"6"}
         colorPalette="brand"
       >
-        <HStack>
+        <Stack direction={{ base: "column", md: "row" }}>
           {modeOptions.map((item) => (
             <RadioGroup.Item key={item.value} value={item.value as string}>
               <RadioGroup.ItemHiddenInput />
@@ -94,10 +92,10 @@ export default function PeriodSelector(
               <RadioGroup.ItemText>{item.label}</RadioGroup.ItemText>
             </RadioGroup.Item>
           ))}
-        </HStack>
+        </Stack>
       </RadioGroup.Root>
       {mode == "custom" && (
-        <Stack direction={"row"} gap={"4"} p={"4"}>
+        <Stack direction={{ base: "column", md: "row" }} gap={"4"} p={"4"}>
           <DateSelector
             label="From"
             value={[customDates.from_ts]}

--- a/apps/web/src/components/features/attachment/attachment_graph.tsx
+++ b/apps/web/src/components/features/attachment/attachment_graph.tsx
@@ -1,5 +1,6 @@
 import type { TimeSeries } from "@/typing"
 import { Chart, useChart } from "@chakra-ui/charts"
+import { useBreakpointValue } from "@chakra-ui/react";
 import { Line, LineChart, XAxis, YAxis, CartesianGrid, Tooltip } from "recharts"
 
 export default function AttachmentGraph(
@@ -7,21 +8,25 @@ export default function AttachmentGraph(
 ) {
     const chart = useChart({ data });
 
-    return (
+    const chartWidth = useBreakpointValue({ base: 300, md: 500, lg: 700, xl: 1000 });
+    const fontSize = useBreakpointValue({ base: "12px", md: "13px" });
+    const lableFontSize = useBreakpointValue({ base: "13px", md: "15px" });
+    const labelStyleProps = { fontSize: lableFontSize, fontWeight: "bold" };
 
+    return (
         <Chart.Root chart={chart} mt={"6"}>
-            <LineChart data={data} width={1000} height={500}>
+            <LineChart data={data} width={chartWidth} height={500}>
                 <CartesianGrid vertical={false} />
                 <XAxis
                     dataKey={"day"}
-                    label={{ value: "DATE", position: "bottom", style: { fontSize: "15px", fontWeight: "bold" } }}
+                    label={{ value: "DATE", position: "bottom", style: labelStyleProps }}
                     interval="preserveStartEnd"
                     tickLine={false}
                     axisLine={false}
                     tickFormatter={(day) => new Date(day).toLocaleDateString(
-                        "en-US", {month: "short", day: "2-digit", year: "numeric"}
+                        "en-US", { month: "short", day: "2-digit", year: "numeric" }
                     )}
-                    tick={{ style: {fontSize: "13px"}}}
+                    tick={{ style: { fontSize: fontSize } }}
                     tickMargin={5}
                     minTickGap={30}
                 />
@@ -30,7 +35,7 @@ export default function AttachmentGraph(
                         value: "ATTACHMENT INDEX",
                         position: "left",
                         angle: -90,
-                        style: { fontSize: "15px", fontWeight: "bold"}
+                        style: labelStyleProps
                     }}
                     axisLine={false}
                 />

--- a/apps/web/src/components/features/attachment/attachment_moments.tsx
+++ b/apps/web/src/components/features/attachment/attachment_moments.tsx
@@ -6,7 +6,8 @@ import {
     Badge,
     Text as ChakraText,
     Collapsible,
-    Alert
+    Alert,
+    useBreakpointValue,
 } from "@chakra-ui/react";
 import { useState } from "react";
 
@@ -23,7 +24,7 @@ function formatName(
 }
 
 function MomentCard(
-    { item, key }: { item: AttachmentMoment, key: number }
+    { item, key }: { item: AttachmentMoment, key: string }
 ) {
     const { day, z_score } = item;
     const date = new Date(day);
@@ -48,7 +49,7 @@ function MomentCard(
             overflow={"auto"}
             key={key}
         >
-            <Box w={"240px"}>
+            <Box w={{ base: "200px", md: "240px" }}>
                 <Collapsible.Root
                     unmountOnExit
                     open={open}
@@ -126,13 +127,14 @@ function SnakeGroup(
     }
 ) {
     const isEvenRow = index % 2 === 0;
+    const isMobile = useBreakpointValue({ base: true, md: false }) || false;
     return (
         <Flex
-            key={index}
-            direction={isEvenRow ? "row" : "row-reverse"}
+            key={`momentgroup.${index}`}
+            direction={{ base: "column", md: isEvenRow ? "row" : "row-reverse" }}
             gap="10"
             position={"relative"}
-            _after={index < totalGroups - 1 ? {
+            _after={!isMobile && index < totalGroups - 1 ? {
                 content: '""',
                 position: "absolute",
                 top: "95%",
@@ -146,9 +148,9 @@ function SnakeGroup(
             } : {}}
         >
             {group.map((item, idx) => (
-                <Box key={idx} position="relative">
-                    <MomentCard item={item} key={idx} />
-                    {((isEvenRow && idx < group.length - 1) || (!isEvenRow && idx > 0)) && (
+                <Box key={`momentbox.${index}.${idx}`} position="relative">
+                    <MomentCard item={item} key={`moment.${index}.${idx}`} />
+                    {((isEvenRow && idx < group.length - 1) || (!isEvenRow && idx > 0)) && !isMobile && (
                         <Box
                             position="absolute"
                             top="50px"
@@ -171,7 +173,7 @@ export default function AttachmentTimeline(
     if (moments.length === 0) {
         return (
             <Flex justify={"center"}>
-                <Alert.Root status={"info"} width={"sm"} justifySelf={"center"}>
+                <Alert.Root status={"info"} width={{ base: "250px", md: "sm" }} justifySelf={"center"}>
                     <Alert.Indicator />
                     <Alert.Content>
                         <Alert.Title>No attachment moments found in the selected period.</Alert.Title>
@@ -180,9 +182,10 @@ export default function AttachmentTimeline(
             </Flex>
         )
     }
-    const groups = groupMoments(moments, 4);
+    const groupSize = useBreakpointValue({ base: 1, md: 2, lg: 3, xl: 4 });
+    const groups = groupMoments(moments, groupSize || 1);
     return (
-        <Flex direction="column" gap={12} mt={6} position="relative">
+        <Flex direction="column" gap={{ base: 8, md: 12 }} mt={6} position="relative">
             {groups.map((group, index) => (
                 <SnakeGroup
                     group={group}

--- a/apps/web/src/components/features/overview/recent_activity.tsx
+++ b/apps/web/src/components/features/overview/recent_activity.tsx
@@ -1,5 +1,5 @@
 import { ResponsiveTimeRange } from "@nivo/calendar";
-import { useToken } from "@chakra-ui/react";
+import { Box, useBreakpointValue, useToken } from "@chakra-ui/react";
 
 interface ScrobblesCount {
     day: string,
@@ -16,6 +16,11 @@ export default function RecentActivity(
     { from_date, to_date, counts }: RecentActivityObject
 ) {
 
+    const chartWidth = useBreakpointValue({ base: 300, md: 600 });
+    const margin = useBreakpointValue({ base: 0, md: 20 });
+    const radius = useBreakpointValue({ base: 3, md: 5 });
+    const chartHeight = useBreakpointValue({ base: 200, md: 250});
+
     const theme = {
         labels: {
             text: {
@@ -23,9 +28,9 @@ export default function RecentActivity(
                 fill: "var(--chakra-colors-fg-muted)",
                 fontFamily: "var(--chakra-fonts-body)",
                 fontWeight: "500",
-                },
             },
-  
+        },
+
         tooltip: {
             container: {
                 fontFamily: "var(--chakra-fonts-body)",
@@ -38,32 +43,35 @@ export default function RecentActivity(
 
     const [emptyColor, c0, c1, c2, c3, c4] = useToken(
         "colors.activityColors", [
-            "empty",
-            "c0",
-            "c1",
-            "c2",
-            "c3",
-            "c4"
-        ]
+        "empty",
+        "c0",
+        "c1",
+        "c2",
+        "c3",
+        "c4"
+    ]
     )
     return (
-        <div style={{ height: 250, width: 600 }}>
-        <ResponsiveTimeRange
-        data={counts}
-        theme={theme}
-        from={`${from_date}T00:00:00`}
-        to={`${to_date}T23:59:59`}
-        emptyColor={ emptyColor }
-        colors={ [c0, c1, c2, c3, c4] }
-        maxValue={"auto"}
-        minValue={0}
-        margin={{ top: 40, right: 20, bottom: 0, left: 20 }}
-        dayBorderColor=""
-        daySpacing={3}
-        dayRadius={5}
-        monthLegendOffset={20}
-        monthLegend={(_year, _month, date) => `${date.toLocaleDateString("default", {month: "long"})}`}
-        />
-        </div>
+        <Box height={chartHeight} width={chartWidth}>
+            <ResponsiveTimeRange
+                data={counts}
+                theme={theme}
+                from={`${from_date}T00:00:00`}
+                to={`${to_date}T23:59:59`}
+                emptyColor={emptyColor}
+                colors={[c0, c1, c2, c3, c4]}
+                maxValue={"auto"}
+                minValue={0}
+                margin={{ top: 40, right: margin, bottom: 0, left: margin }}
+                dayBorderColor=""
+                daySpacing={3}
+                dayRadius={radius}
+                monthLegendOffset={20}
+                monthLegend={(_year, _month, date) => `${date.toLocaleDateString("default", { month: "short" })}`}
+                weekdayTicks={[1, 3, 5]}
+                weekdays={["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]}
+                weekdayLegendOffset={40}
+            />
+        </Box>
     )
 }

--- a/apps/web/src/components/features/overview/topcharts_preview.tsx
+++ b/apps/web/src/components/features/overview/topcharts_preview.tsx
@@ -13,7 +13,6 @@ export default function TopChartsPreview(
     return (
         <Table.Root
             size="sm"
-            width="sm"
         >
             <Table.Header>
                 <Table.Row borderBottomWidth="1px">

--- a/apps/web/src/components/features/topcharts/topcharts_table.tsx
+++ b/apps/web/src/components/features/topcharts/topcharts_table.tsx
@@ -2,7 +2,6 @@ import { Box, ButtonGroup, IconButton, Pagination, Progress, Table, Text as Chak
 import type { TopChart } from "@/typing";
 import { useState } from "react";
 import { MdChevronLeft, MdChevronRight } from "react-icons/md";
-import { ResponsiveContainer } from "recharts";
 
 export default function TopChartsTable(
     { kind, topCharts, pageSize }: { kind: string, topCharts: TopChart[], pageSize: number }
@@ -19,74 +18,73 @@ export default function TopChartsTable(
 
 
     return (
-        <ResponsiveContainer width={600} height={1000}>
-            <Table.Root
-                size="lg"
-                width="2xl"
-            >
-                <Table.Header>
-                    <Table.Row borderBottomWidth="1px">
-                        <Table.ColumnHeader
-                            color="fg.muted"
-                            letterSpacing="wider"
-                            fontSize="md"
-                            textTransform={"uppercase"}
-                        >
-                            {kind}
-                        </Table.ColumnHeader>
-                        <Table.ColumnHeader
-                            textAlign="end"
-                            color="fg.muted"
-                            letterSpacing="wider"
-                            fontSize="md"
-                        >
-                            SCROBBLES
-                        </Table.ColumnHeader>
-                    </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                    {paginatedCharts.map((chart) => (
-                        <Table.Row
-                            key={chart.name}
-                            borderBottomWidth={"2px"}
-                            borderBottomColor={"bg"}
-                        >
-                            <Table.Cell py="3" fontWeight="500" width={"md"}>
-                                <Box>
-                                    <ChakraText>
-                                        {chart.name}
-                                    </ChakraText>
-
-                                    {chart.subname && (
-                                        <ChakraText fontSize="xs" color="fg.muted">
-                                            {chart.subname}
-                                        </ChakraText>
-                                    )}
-                                </Box>
-                            </Table.Cell>
-                            <Table.Cell py="3" textAlign="end" >
-                                <Progress.Root
-                                    value={chart.scrobbles}
-                                    max={max}
-                                    colorPalette="brand"
-                                    variant="subtle"
-                                    shape="rounded"
-                                    size={"lg"}
-                                    minWidth="200px"
-                                >
-
-                                    <Progress.ValueText fontSize={"sm"}>
-                                        {chart.scrobbles}
-                                    </Progress.ValueText>
-                                    <Progress.Track>
-                                        <Progress.Range />
-                                    </Progress.Track>
-                                </Progress.Root>
-                            </Table.Cell>
+            <Box w={"full"} direction={"column"}>
+                <Table.Root
+                    size={{base: "sm", md:"lg"}}
+                >
+                    <Table.Header>
+                        <Table.Row borderBottomWidth="1px">
+                            <Table.ColumnHeader
+                                color="fg.muted"
+                                letterSpacing="wider"
+                                fontSize="md"
+                                textTransform={"uppercase"}
+                            >
+                                {kind}
+                            </Table.ColumnHeader>
+                            <Table.ColumnHeader
+                                textAlign="end"
+                                color="fg.muted"
+                                letterSpacing="wider"
+                                fontSize="md"
+                            >
+                                SCROBBLES
+                            </Table.ColumnHeader>
                         </Table.Row>
-                    ))}
-                </Table.Body>
-            </Table.Root>
+                    </Table.Header>
+                    <Table.Body>
+                        {paginatedCharts.map((chart) => (
+                            <Table.Row
+                                key={chart.name}
+                                borderBottomWidth={"2px"}
+                                borderBottomColor={"bg"}
+                            >
+                                <Table.Cell py="3" fontWeight="500">
+                                    <Box>
+                                        <ChakraText>
+                                            {chart.name}
+                                        </ChakraText>
+
+                                        {chart.subname && (
+                                            <ChakraText fontSize="xs" color="fg.muted">
+                                                {chart.subname}
+                                            </ChakraText>
+                                        )}
+                                    </Box>
+                                </Table.Cell>
+                                <Table.Cell py="3" textAlign="end" >
+                                    <Progress.Root
+                                        value={chart.scrobbles}
+                                        max={max}
+                                        colorPalette="brand"
+                                        variant="subtle"
+                                        shape="rounded"
+                                        size={{base: "xs", md: "lg"}}
+                                        minWidth={{md: "200px"}}
+                                    >
+
+                                        <Progress.ValueText fontSize={"sm"}>
+                                            {chart.scrobbles}
+                                        </Progress.ValueText>
+                                        <Progress.Track>
+                                            <Progress.Range />
+                                        </Progress.Track>
+                                    </Progress.Root>
+                                </Table.Cell>
+                            </Table.Row>
+                        ))}
+                    </Table.Body>
+                </Table.Root>
             <Pagination.Root
                 count={topCharts.length}
                 pageSize={pageSize}
@@ -121,6 +119,6 @@ export default function TopChartsTable(
                     </Pagination.NextTrigger>
                 </ButtonGroup>
             </Pagination.Root>
-        </ResponsiveContainer>
+        </Box>
     )
 }

--- a/apps/web/src/components/layout/headerbar.tsx
+++ b/apps/web/src/components/layout/headerbar.tsx
@@ -24,10 +24,11 @@ export default function HeaderBar (
           h="16"
           width="100%"
           position={"sticky"}
-          zIndex={"sticky"}
+          top={0}
+          zIndex="sticky"
           bg={"bg.muted"}
           padding={5}
-          py="10"
+          py={{base: "4", md: "10"}}
         >
           <Flex align="center" gap="4">
             <IconButton 

--- a/apps/web/src/components/layout/layout.tsx
+++ b/apps/web/src/components/layout/layout.tsx
@@ -22,7 +22,15 @@ export default function AppLayout() {
   const externalLinks = useExternalLinks();
 
   const { open } = useSidebarNav();
-  const sidebarWidth = open ? "260px" : "72px";
+  const mobileWidth = open ? "260px" : "52px";
+  const mdWidth = open ? "260px" : "72px";
+  const sidebarWidth = { base: mobileWidth, md: mdWidth };
+  const topPosition = { base: "64px", md: "80px" }
+
+  const dynamicHeight = {
+    base: `calc(100vh - ${topPosition.base})`,
+    md: `calc(100vh - ${topPosition.md})`
+  };
 
   return (
     <Flex minH={"100vh"} direction={"column"}>
@@ -31,11 +39,16 @@ export default function AppLayout() {
       <HeaderBar username={username!} />
 
       {/* Sidebar */}
-      <Flex flex="1" overflow={"hidden"}>
+      <Flex flex="1">
         <Box
           w={sidebarWidth}
           bg="bg.muted"
           boxShadow={"md"}
+          position="sticky"
+          zIndex="docked"
+          top={topPosition}
+          h={dynamicHeight}
+
         >
           <SidebarNav navItems={navItems} externalLinks={externalLinks} />
         </Box>
@@ -50,6 +63,6 @@ export default function AppLayout() {
           <Outlet />
         </Box>
       </Flex>
-    </Flex>
+    </Flex >
   );
 }

--- a/apps/web/src/components/layout/nav_sidebar/nav_items.tsx
+++ b/apps/web/src/components/layout/nav_sidebar/nav_items.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, List, Text as ChakraText, Link, VStack, Separator, } from "@chakra-ui/react";
+import { Box, Flex, List, Text as ChakraText, Link, VStack, Separator, useBreakpointValue, } from "@chakra-ui/react";
 import type { IconType } from "react-icons";
 import { NavLink } from "react-router-dom";
 import { useSidebarNav } from "./nav_sidebar_context";
@@ -25,6 +25,8 @@ function sidebarItem(
 ) {
 
   const { open } = useSidebarNav();
+  const iconSize = useBreakpointValue({ base: "16px", md: "20px" });
+  const textSize = useBreakpointValue({ base: "12px", md: "16px" });
 
   return (
     <List.Item key={index} listStyle={"none"}>
@@ -42,10 +44,10 @@ function sidebarItem(
             color={isActive ? "white" : "inherit"}
             _hover={!isActive ? { bg: "bg.subtle" } : {}}
           >
-            <Flex align="center" gap="4" px="3" py="2">
-              <Box fontSize="20px"><item.icon /></Box>
+            <Flex align="center" gap="2" px="2.5" py="2">
+              <Box fontSize={iconSize}><item.icon /></Box>
               {open && (
-                <ChakraText fontWeight="medium">{item.label}</ChakraText>
+                <ChakraText fontWeight="medium" fontSize={textSize}>{item.label}</ChakraText>
               )}
             </Flex>
           </Box>
@@ -59,6 +61,8 @@ function sidebarItem(
 function ExternalItem(item: ExternalLinkItem, index: number) {
 
   const { open } = useSidebarNav();
+  const iconSize = useBreakpointValue({ base: "16px", md: "20px" });
+  const textSize = useBreakpointValue({ base: "12px", md: "16px" });
 
   return (
     <List.Item key={index} listStyle={"none"}>
@@ -75,10 +79,10 @@ function ExternalItem(item: ExternalLinkItem, index: number) {
           transition="all 0.2s"
           _hover={{ bg: "bg.subtle" }}
         >
-          <Flex align="center" gap="4" px="3" py="2">
-            <Box fontSize="20px"><item.icon /></Box>
+          <Flex align="center" gap="2" px="2.5" py="2">
+            <Box fontSize={iconSize}><item.icon /></Box>
             {open && (
-              <ChakraText fontWeight="medium">{item.label}</ChakraText>
+              <ChakraText fontWeight="medium" fontSize={textSize}>{item.label}</ChakraText>
             )}
           </Flex>
         </Box>

--- a/apps/web/src/components/layout/nav_sidebar/nav_sidebar.config.ts
+++ b/apps/web/src/components/layout/nav_sidebar/nav_sidebar.config.ts
@@ -13,5 +13,5 @@ export const useNavItems = (username: string): SidebarNavItem[] => [
 export const useExternalLinks = (): ExternalLinkItem[] => [
     { icon: MdOutlineFeedback, label: "Feedback", href: "https://tally.so/r/Y5JVpz" },
     { icon: FaGithub, label: "GitHub", href: "https://github.com/shsiddhant/memory.fm/" },
-    { icon: MdOutlineVolunteerActivism, label: "Support Development", href: "https://ko-fi.com/shsiddhant" },
+    { icon: MdOutlineVolunteerActivism, label: "Support Us", href: "https://ko-fi.com/shsiddhant" },
 ];

--- a/apps/web/src/components/layout/nav_sidebar/nav_sidebar.tsx
+++ b/apps/web/src/components/layout/nav_sidebar/nav_sidebar.tsx
@@ -20,7 +20,7 @@ export default function SidebarNav(
       transition="all 0.2s ease"
       overflowX="hidden"
     >
-      <Stack p={"4"} gap={"4"}>
+      <Stack p={{ base: "2", md: "4" }} gap={"4"}>
         <SidebarNavItems navItems={navItems} externalLinks={externalLinks} />
       </Stack>
     </Box>

--- a/apps/web/src/components/pages/attachment.tsx
+++ b/apps/web/src/components/pages/attachment.tsx
@@ -109,14 +109,13 @@ export default function AttachmentPage() {
             <Flex
                 justify="space-around"
                 wrap="wrap"
-                gap={4}
                 padding={"4"}
-                mx={"12"}
-                mt={"4"}
+                mx={{ base: 0, md: 12 }}
+                mt="4"
             >
-                <VStack align="center" gap={"4"} px="6" py="3">
+                <VStack align="center" gap={"4"} px={{base: 2, md: 6}} py="3">
                     <ChakraText
-                        fontSize={"lg"}
+                        fontSize={{base: "sm", md: "lg"}}
                         fontWeight={"bold"}
                     >Period</ChakraText>
                     <PeriodSelector
@@ -142,7 +141,7 @@ export default function AttachmentPage() {
                 <LoadingSpinner />
             ) : (
                 <Flex justify={"center"}>
-                    <Alert.Root status={"info"} width={"sm"} justifySelf={"center"}>
+                    <Alert.Root status={"info"} width={{base: "auto", md: "sm"}} justifySelf={"center"}>
                         <Alert.Indicator />
                         <Alert.Content>
                             <Alert.Title>No scrobbles found in the selected period.</Alert.Title>

--- a/apps/web/src/components/pages/overview.tsx
+++ b/apps/web/src/components/pages/overview.tsx
@@ -97,7 +97,7 @@ export default function Overview() {
         queryClient.invalidateQueries({
             queryKey: ["summaryQuery", username]
         });
-        
+
 
     }, [syncStatus?.status, syncStatus?.fetched_scrobbles, username, queryClient]);
 
@@ -194,15 +194,18 @@ export default function Overview() {
                     <Section
                         title={`Top Charts - Last ${period} Days`}
                     >
-                        <Flex direction={"row"} gap="10" justify={"space-between"}>
+                        <Box flexShrink={{ base: 0, md: 1 }} width={{ base: "250px", md: "full" }}>
                             <TopChartsPreview {...topArtistsInput} />
-                            <Separator />
+                        </Box>
+                        <Separator />
+                        <Box flexShrink={{ base: 0, md: 1 }} width={{ base: "250px", md: "full" }}>
                             <TopChartsPreview {...topTracksInput} />
-                        </Flex>
+                        </Box>
                     </Section>
                 </>
-            )}
-        </Flex>
+            )
+            }
+        </Flex >
     );
 }
 

--- a/apps/web/src/components/pages/topcharts.tsx
+++ b/apps/web/src/components/pages/topcharts.tsx
@@ -99,16 +99,17 @@ export default function TopChartsPage() {
                 <KindSelector value={params.kind} onKindChange={setKind} />
             </Box>
             <Flex
+                direction={{base: "column", md: "row"}}
                 justify="space-around"
                 wrap="wrap"
                 gap={4}
                 padding={"4"}
-                mx={"12"}
+                mx={{ base: 0, md: 12 }}
                 mt={"4"}
             >
-                <VStack align="center" gap={"4"} px="6" py="3">
+                <VStack align="center" gap={"4"} px={{base: 2, md: 6}} py="3">
                     <ChakraText
-                        fontSize={"lg"}
+                        fontSize={{base: "sm", md: "lg"}}
                         fontWeight={"bold"}
                     >Period</ChakraText>
                     <PeriodSelector
@@ -118,9 +119,9 @@ export default function TopChartsPage() {
                         onDatesChange={handleDateChange}
                     />
                 </VStack>
-                <VStack align={"center"} gap={"4"} padding={"6"}>
+                <VStack align="center" gap={"4"} px={{ base: 0, md: 6 }} py="3">
                     <ChakraText
-                        fontSize={"lg"}
+                        fontSize={{base: "sm", md: "lg"}}
                         fontWeight={"bold"}
                     >Limit</ChakraText>
                     <LimitSelector
@@ -132,21 +133,24 @@ export default function TopChartsPage() {
             </Flex>
             {(!loading && data && data.length > 0) ? (
                 <>
-                <Section
-                title={`Top ${params.kind}s`}
-                children={<TopChartsTable kind={params.kind} topCharts={data} pageSize={8}/>}
-                />
+                    <Section
+                        title={`Top ${params.kind}s`}
+                    >
+                        <Box width={{ base: "250px", md: "full" }}>
+                            <TopChartsTable kind={params.kind} topCharts={data} pageSize={8} />
+                        </Box>
+                    </Section>
                 </>
             ) : (loading) ? (
                 <LoadingSpinner />
-            ): (
+            ) : (
                 <Flex justify={"center"}>
-                <Alert.Root status={"info"} width={"sm"} justifySelf={"center"}>
-                    <Alert.Indicator />
-                    <Alert.Content>
-                        <Alert.Title>No scrobbles found in the selected period.</Alert.Title>
-                    </Alert.Content>
-                </Alert.Root>
+                    <Alert.Root status={"info"} width={{base: "250px", md: "sm"}} justifySelf={"center"}>
+                        <Alert.Indicator />
+                        <Alert.Content>
+                            <Alert.Title>No scrobbles found in the selected period.</Alert.Title>
+                        </Alert.Content>
+                    </Alert.Root>
                 </Flex>
             )}
         </Flex>

--- a/apps/web/src/components/ui/section.tsx
+++ b/apps/web/src/components/ui/section.tsx
@@ -14,8 +14,14 @@ const Section = ({ title, children }: SectionProps) => {
       <Box width="full" maxW="1200px" mx={"auto"}>
         <SectionSeparator title={title} colorToken="ticks" />
       </Box>
-        <Box as="section" mb="12" justifyItems={"center"}>
-          <Stack className="content" h="full">
+        <Box as="section" mb={{base: 0, md: 8}} justifyItems={"center"}>
+          <Stack
+            className="content"
+            h="full"
+            direction={{ base: "column", lg: "row"}}
+            gap={10}
+            minW="max-content"
+            >
             {children}
           </Stack>
         </Box>

--- a/apps/web/src/components/ui/ticks.tsx
+++ b/apps/web/src/components/ui/ticks.tsx
@@ -18,7 +18,7 @@ export const SectionSeparator = ({
   }
 
   return (
-    <Flex align="center" gap="4" w="90%" my="8" justifySelf={"center"} mt={12}>
+    <Flex align="center" gap="4" w="90%" my={{base: 4, md: 8}} justifySelf={"center"} mt={12}>
       <Box
         flex="1"
         h="1px"
@@ -33,12 +33,12 @@ export const SectionSeparator = ({
 
         {title && (
         <ChakraText
-          fontSize="md"
+          fontSize={{base: "sm", md: "md"}}
           fontWeight="bold"
           color="fg.muted"
           textTransform="uppercase"
           letterSpacing="widest"
-          whiteSpace="nowrap"
+          lineBreak={"auto"}
         >
           {title}
         </ChakraText>


### PR DESCRIPTION
## Pull Request Summary

This PR improves Web UI to make it usable on smaller screens such as smartphones.

## Type of Change

- [x]  New Feature

## Changes

### Layout

- Make HeaderBar sticky.
- Make Navigation Sidebar docked with correct height.
- Use correct widths, padding, font size, and flex layout by breakpoint in:
    - Headerbar and Navigation Sidebar
    - Section and SectionSeparator components

### Web UI/UX

- Improve mobile usability by using correct widths, padding, font size, and flex layout by breakpoint in: 
  - params selection components
  - Overview page and its components RecentActivity, TopChartsPreview
  - Top Charts page and TopChartsTable
  - AttachmentPage and its components AttachmentGraph, AttachmentTimeline
