### PR TITLE
web: improve sync progress and completed alert ui.

### DIFF
--- a/apps/web/src/components/features/overview/no_scrobbles.tsx
+++ b/apps/web/src/components/features/overview/no_scrobbles.tsx
@@ -4,7 +4,7 @@ import { useStartSync } from "@/hooks/use_start_sync";
 
 
 export default function NoScrobbles(
-    { username, syncStatus, isSyncActive}: {
+    { username, syncStatus, isSyncActive }: {
         username: string,
         syncStatus: SyncStatus,
         isSyncActive: boolean,
@@ -20,39 +20,38 @@ export default function NoScrobbles(
     const inProgress = syncStatus != null && syncStatus.status == "progress";
     const isCompleted = syncStatus?.status == "completed";
 
-    const isLoadingSyncButton = 
+    const isLoadingSyncButton =
         isSyncActive ||
         syncStatus?.status == "started" ||
         inProgress;
-    
+
     const showWarning =
         !isSyncActive &&
         !inProgress &&
         !isCompleted;
 
-
     return (
-    <VStack gap={"10"} width={"full"}>
-        <Box width="sm">
-            {showWarning && (
-                <Alert.Root status={"warning"} title="Title">
-                    <Alert.Indicator />
-                    <Alert.Content>
-                        <Alert.Description>
-                            No Scrobbles found! Please sync scrobbles using the sync button below.
-                        </Alert.Description>
-                    </Alert.Content>
-                </Alert.Root>
-            )}
-        </Box>
-        <Button
-            h="10"
-            onClick={handleClick}
-            loading={isLoadingSyncButton}
-            loadingText="Syncing..."
-        >
-            Sync
-        </Button>
-    </VStack>
+        <VStack gap={"10"} width={"full"}>
+            <Box width={{ base: "250px", md: "sm" }}>
+                {showWarning && (
+                    <Alert.Root status={"warning"} title="Title">
+                        <Alert.Indicator />
+                        <Alert.Content>
+                            <Alert.Description>
+                                No Scrobbles found! Please sync scrobbles using the sync button below.
+                            </Alert.Description>
+                        </Alert.Content>
+                    </Alert.Root>
+                )}
+            </Box>
+            <Button
+                h="10"
+                onClick={handleClick}
+                loading={isLoadingSyncButton}
+                loadingText="Syncing..."
+            >
+                Sync
+            </Button>
+        </VStack>
     )
 } 

--- a/apps/web/src/components/features/overview/sync_complete_alert.tsx
+++ b/apps/web/src/components/features/overview/sync_complete_alert.tsx
@@ -9,20 +9,20 @@ export default function SyncCompleteAlert(
     return (
         <Flex
             direction={"column"}
-            padding={5}
+            padding={{base: 2, md: 5 }}
             mb={"6"}
             align="center"
             alignItems={"center"}
         >
-            <Alert.Root status={"info"} width={"sm"}>
+            <Alert.Root status={"info"} width={{ base: "250px", md: "xs"}}>
                 <Alert.Indicator />
                 <Alert.Content>
-                    <Alert.Title>Fetched {fetched! - 1} scrobble{fetched! == 1 ? "s" : ""}.</Alert.Title>
+                    <Alert.Title>Fetched {fetched! - 1} scrobble{fetched! != 1 ? "s" : ""}</Alert.Title>
                 </Alert.Content>
                 <CloseButton
                     position="absolute"
-                    right="1" 
-                    top="1" 
+                    right="-1"
+                    top="1"
                     onClick={() => onClose()} />
             </Alert.Root>
         </Flex>

--- a/apps/web/src/components/features/overview/sync_progress.tsx
+++ b/apps/web/src/components/features/overview/sync_progress.tsx
@@ -13,7 +13,7 @@ export default function SyncProgress(
         return (
             <VStack mb={6}
             >
-                <Box w={"md"}>
+                <Box w={{ base: "xs", md: "md" }}>
                     <Alert.Root status={"error"} title="Sync Error">
                         <Alert.Indicator />
                         <Alert.Content>
@@ -53,19 +53,22 @@ export default function SyncProgress(
         >
             <Progress.Root
                 value={progressPercent}
-                width="xl"
+                width={{ base: "250px", md: "xl" }}
             >
                 <HStack gap={"5"}>
-                    <Progress.Label>Syncing scrobbles...</Progress.Label>
-                    <Progress.Track flex="1" height="2">
+                    <Progress.Label>Syncing...</Progress.Label>
+                    <Progress.Track flex="1" height={{ base: 1, md: 2 }}>
                         <Progress.Range />
                     </Progress.Track>
                     <Progress.ValueText>
-                        {progressPercent.toPrecision(3)}% ({syncStatus.fetched_scrobbles}/{syncStatus.total_scrobbles})
+                        {progressPercent.toPrecision(3)}% {/*({syncStatus.fetched_scrobbles}/{syncStatus.total_scrobbles})*/}
                     </Progress.ValueText>
                 </HStack>
+                <Progress.Label mt={2}>
+                    Fetched {syncStatus.fetched_scrobbles?.toLocaleString()} of {syncStatus.total_scrobbles?.toLocaleString()} scrobbles
+                </Progress.Label>
             </Progress.Root>
-            <Alert.Root status={"info"} width={"md"} justifySelf={"center"}>
+            <Alert.Root status={"info"} width={{ base: "auto", md: "md" }} justifySelf={"center"}>
                 <Alert.Indicator />
                 <Alert.Content>
                     <Alert.Title>First sync may take some time for large listening histories.</Alert.Title>


### PR DESCRIPTION
## Pull Request Summary

This PR improves the sync progress and completion UI, making them more usable on smaller screens.

## Type of Change

- [x]  New Feature

## Changes

- Fix widths and padding of sync progress, error alert, and completed alert according to breakpoints to make them more usable on smaller screens.
- Show fetched scrobbles status below sync progress bar. This helps reduce congestion and keeps sync progress bar properly visible on mobile devices.
- Fix scrobble/scrobbles in completed alert based on fetched scrobbles count.